### PR TITLE
Upgrade from PG 13 to PG 15 & move to sclorg images

### DIFF
--- a/bundle/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pulp-operator.clusterserviceversion.yaml
@@ -1089,7 +1089,7 @@ spec:
                 - name: RELATED_IMAGE_PULP_REDIS
                   value: redis:latest
                 - name: RELATED_IMAGE_PULP_POSTGRES
-                  value: postgres:13
+                  value: quay.io/sclorg/postgresql-15-c9s:latest
                 - name: RELATED_IMAGE_PULP_INIT_GPG_CONTAINER
                   value: quay.io/centos/centos:stream9
                 image: quay.io/pulp/pulp-operator:v0.15.0.dev
@@ -1308,6 +1308,6 @@ spec:
     name: pulp-web
   - image: redis:latest
     name: pulp-redis
-  - image: postgres:13
+  - image: quay.io/sclorg/postgresql-15-c9s:latest
     name: pulp-postgres
   version: 0.15.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -61,7 +61,7 @@ spec:
             - name: RELATED_IMAGE_PULP_REDIS
               value: redis:latest
             - name: RELATED_IMAGE_PULP_POSTGRES
-              value: postgres:13
+              value: quay.io/sclorg/postgresql-15-c9s:latest
             - name: RELATED_IMAGE_PULP_INIT_GPG_CONTAINER
               value: quay.io/centos/centos:stream9
         securityContext:

--- a/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
@@ -943,7 +943,7 @@ spec:
                 - name: RELATED_IMAGE_PULP_REDIS
                   value: redis:latest
                 - name: RELATED_IMAGE_PULP_POSTGRES
-                  value: postgres:13
+                  value: quay.io/sclorg/postgresql-15-c9s:latest
                 - name: RELATED_IMAGE_PULP_INIT_GPG_CONTAINER
                   value: quay.io/centos/centos:stream9
                 image: quay.io/pulp/pulp-operator:devel

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -12,7 +12,8 @@ backup_storage_requirements: ''
 # Specify storage class to determine how to dynamically create PVC's with
 backup_storage_class: ''
 
-postgres_version: 13
+postgres_version: 15
+_postgres_image: quay.io/sclorg/postgresql-15-c9s:latest
 
 # Secret Names
 admin_password_secret: "{{ deployment_name }}-admin-password"

--- a/roles/backup/vars/main.yml
+++ b/roles/backup/vars/main.yml
@@ -1,4 +1,5 @@
 ---
 
 deployment_type: "pulp"
-_postgres_image: postgres:13
+postgres_version: 15
+_postgres_image: quay.io/sclorg/postgresql-15-c9s:latest

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -1,8 +1,9 @@
 ---
 deployment_type: pulp
 
-postgres_version: 13
-_postgres_image: postgres:13
+postgres_version: 15
+old_postgres_pod: []
+_postgres_image: quay.io/sclorg/postgresql-15-c9s:latest
 
 postgres_storage_requirements:
   requests:

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -79,7 +79,6 @@
         lastTransitionTime: "{{ lookup('pipe', 'date --iso-8601=seconds') }}"
 
 - block:
-
     - name: Create Database configuration
       k8s:
         apply: true
@@ -145,16 +144,80 @@
     postgres_label_selector: "app.kubernetes.io/instance=postgres-{{ ansible_operator_meta.name }}"
   when: postgres_label_selector is not defined
 
-- name: Get the old postgres pod information
-  k8s_info:
+# It is possible that N-2 postgres pods may still be present in the namespace from previous upgrades.
+# So we have to take that into account and preferentially set the most recent one.
+- name: Get the old postgres pod (N-1)  k8s_info:
     kind: Pod
     namespace: "{{ ansible_operator_meta.namespace }}"
-    label_selectors:
-      - "{{ postgres_label_selector }}"
-      - "app.kubernetes.io/version=12"
     field_selectors:
       - status.phase=Running
-  register: old_postgres_pod
+  register: _running_pods
+
+- block:
+  - name: Filter pods by name
+    set_fact:
+      filtered_old_postgres_pods: "{{ _running_pods.resources |
+        selectattr('metadata.name', 'match', ansible_operator_meta.name + '-postgres.*-0') |
+        rejectattr('metadata.name', 'search', '-' + postgres_version | string + '-0') |
+        list }}"
+
+  # Sort pods by name in reverse order (most recent PG version first) and set
+  - name: Set info for previous postgres pod
+    set_fact:
+      sorted_old_postgres_pods: "{{ filtered_old_postgres_pods |
+        sort(attribute='metadata.name') |
+        reverse }}"
+    when: filtered_old_postgres_pods | length
+
+
+  - name: Set info for previous postgres pod
+    set_fact:
+      old_postgres_pod: "{{ sorted_old_postgres_pods | first }}"
+    when: filtered_old_postgres_pods | length
+  when: _running_pods.resources | length
+
+- name: Look up details for this deployment
+  k8s_info:
+    api_version: "{{ api_version }}"
+    kind: "{{ kind }}"
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+  register: this_pulp
+
+- name: Set previous PG version var
+  set_fact:
+    _previous_upgraded_pg_version: "{{ this_pulp['resources'][0]['status']['upgradedPostgresVersion'] | default(false) }}"
+  when:
+    - "'upgradedPostgresVersion' in this_pulp['resources'][0]['status']"
+
+- name: Check if postgres pod is running and version
+  block:
+    - name: Set path to PG_VERSION file for given container image
+      set_fact:
+        path_to_pg_version: '{{ postgres_data_path }}/PG_VERSION'
+
+    - name: Get old PostgreSQL version
+      k8s_exec:
+        namespace: "{{ ansible_operator_meta.namespace }}"
+        pod: "{{ old_postgres_pod['metadata']['name'] }}"
+        command: |
+          bash -c """
+          cat {{ path_to_pg_version }}
+          """
+      register: _old_pg_version
+
+    - debug:
+        msg: "--- Upgrading from {{ old_postgres_pod['metadata']['name'] | default('NONE')}} Pod ---"
+
+    - name: Upgrade data dir from old Postgres to {{ postgres_version }} if applicable
+      include_tasks: upgrade_postgres.yml
+      when:
+        - (_old_pg_version.stdout | default(0) | int ) < postgres_version
+  when:
+    - managed_database
+    - (_previous_upgraded_pg_version | default(false)) | ternary(_previous_upgraded_pg_version < postgres_version, true)
+    - old_postgres_pod | length  # If empty, then old pg pod has been removed and we can assume the upgrade is complete
+
 
 - block:
     - k8s_status:
@@ -183,31 +246,6 @@
     name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ ansible_operator_meta.namespace }}"
   register: this_pulp
-
-- name: Check if postgres pod is running and version 12
-  block:
-    - name: Set path to PG_VERSION file for given container image
-      set_fact:
-        path_to_pg_version: '{{ postgres_data_path }}/PG_VERSION'
-
-    - name: Get old PostgreSQL version
-      k8s_exec:
-        namespace: "{{ ansible_operator_meta.namespace }}"
-        pod: "{{ old_postgres_pod['resources'][0]['metadata']['name'] }}"
-        command: |
-          bash -c """
-          cat {{ path_to_pg_version }}
-          """
-      register: _old_pg_version
-
-    - name: Upgrade data dir from Postgres 12 to 13 if applicable
-      include_tasks: upgrade_postgres.yml
-      when:
-        - _old_pg_version.stdout | default('0') | trim == '12'
-  when:
-    - managed_database
-    - this_pulp['resources'][0]['status']['upgradedPostgresVersion'] | default('none') != '12'
-    - old_postgres_pod['resources'] | length  # upgrade is complete and old pg pod has been removed
 
 - name: Migrate data from old Openshift instance
   import_tasks: migrate_data.yml

--- a/roles/postgres/tasks/upgrade_postgres.yml
+++ b/roles/postgres/tasks/upgrade_postgres.yml
@@ -1,8 +1,9 @@
 ---
 
 # Upgrade Postgres (Managed Databases only)
-#  * If postgres version is not 12, and not an external postgres instance (when managed_database is yes),
-#    then run this playbook with include_tasks from database_configuration.yml
+#  * If postgres version is not the default/supported postgres_version, and not an
+#    external postgres instance (when managed_database is yes), then run this playbook
+#    with include_tasks from database_configuration.yml
 #  * Data will be streamed via a pg_dump from the postgres 12 pod to the postgres 13
 #    pod via a pg_restore.
 
@@ -42,7 +43,7 @@
         status: "False"
         lastTransitionTime: "{{ lookup('pipe', 'date --iso-8601=seconds') }}"
 
-- name: Create Database configuration with new -postgres-{{ postgres_version }} hostname
+- name: Create Database configuration secret with new -postgres-{{ postgres_version }} hostname
   k8s:
     apply: true
     definition: "{{ lookup('template', 'postgres_upgrade.secret.yaml.j2') }}"
@@ -123,9 +124,19 @@
   set_fact:
     postgres_pod_name: "{{ postgres_pod['resources'][0]['metadata']['name'] }}"
 
+- name: Get the name of the service for the old postgres pod
+  k8s_info:
+    kind: Service
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    label_selectors:
+      - "app.kubernetes.io/component=database"
+      - "app.kubernetes.io/instance={{ old_postgres_pod.metadata.labels['app.kubernetes.io/instance'] }}"
+      - "app.kubernetes.io/managed-by=pulp-operator"
+  register: old_postgres_svc
+
 - name: Set full resolvable host name for old postgres pod
   set_fact:
-    resolvable_db_host: "{{ ansible_operator_meta.name }}-postgres-svc.{{ ansible_operator_meta.namespace }}.svc.cluster.local"  # yamllint disable-line rule:line-length
+    resolvable_db_host: "{{ old_postgres_svc['resources'][0]['metadata']['name'] }}.{{ ansible_operator_meta.namespace }}.svc.cluster.local"  # yamllint disable-line rule:line-length
   no_log: "{{ no_log }}"
 
 
@@ -200,7 +211,7 @@
 
 - name: Set flag signifying that this instance has been migrated
   set_fact:
-    upgraded_postgres_version: '13'
+    upgraded_postgres_version: '{{ postgres_version }}'
 
 - k8s_status:
     api_version: "{{ api_version }}"
@@ -220,9 +231,12 @@
     kind: StatefulSet
     api_version: v1
     namespace: "{{ ansible_operator_meta.namespace }}"
-    name: "{{ ansible_operator_meta.name }}-postgres"
+    name: "{{ item }}"
     state: absent
     wait: true
+  loop:
+    - "{{ ansible_operator_meta.name }}-postgres"
+    - "{{ ansible_operator_meta.name }}-postgres-13"
 
 - k8s_status:
     api_version: "{{ api_version }}"
@@ -241,8 +255,11 @@
     kind: Service
     api_version: v1
     namespace: "{{ ansible_operator_meta.namespace }}"
-    name: "{{ ansible_operator_meta.name }}-postgres-svc"
+    name: "{{ item }}"
     state: absent
+  loop:
+    - "{{ ansible_operator_meta.name }}-postgres-svc"
+    - "{{ ansible_operator_meta.name }}-postgres-13"
 
 - k8s_status:
     api_version: "{{ api_version }}"
@@ -261,8 +278,11 @@
     kind: PersistentVolumeClaim
     api_version: v1
     namespace: "{{ ansible_operator_meta.namespace }}"
-    name: "postgres-{{ ansible_operator_meta.name }}-postgres-0"
+    name: "{{ item }}"
     state: absent
+  loop:
+    - "postgres-{{ ansible_operator_meta.name }}-postgres-0"
+    - "postgres-{{ ansible_operator_meta.name }}-postgres-13-0"
   when:
     - postgres_keep_pvc_after_upgrade is defined
     - postgres_keep_pvc_after_upgrade | length

--- a/roles/restore/vars/main.yml
+++ b/roles/restore/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 
 deployment_type: "pulp"
-_postgres_image: postgres:13
+_postgres_image: quay.io/sclorg/postgresql-15-c9s:latest
 
 custom_resource_key: '_pulp_pulpproject_org_pulprestore'
 


### PR DESCRIPTION
Migrated from the original PR:
* https://github.com/pulp/pulp-operator/pull/1069


This PR adds logic to upgrade from PostgreSQL 13 --> PostgreSQL 15 and handle the data migration.  It also streamlines these tasks to make it easier to add upgrade logic in the future.  Finally, it moves to using sclorg images to have consistent data dir paths everywhere.  