### PR TITLE
Configure Bundle CA Cert if provided

### DIFF
--- a/bundle/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pulp-operator.clusterserviceversion.yaml
@@ -430,6 +430,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
+      - description: Secret where the trusted Certificate Authority Bundle is stored
+        path: bundle_cacert_secret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:io.kubernetes:Secret
       - description: Configuration secret for SSO instance
         displayName: SSO configuration
         path: sso_secret

--- a/bundle/manifests/pulp.pulpproject.org_pulps.yaml
+++ b/bundle/manifests/pulp.pulpproject.org_pulps.yaml
@@ -680,6 +680,9 @@ spec:
               signing_secret:
                 description: Secret where the signing certificates are stored
                 type: string
+              bundle_cacert_secret:
+                description: Secret where the trusted Certificate Authority Bundle is stored
+                type: string
               sso_secret:
                 description: Secret where Single Sign-on configuration can be found
                 type: string

--- a/config/crd/bases/pulpproject_v1beta1_pulp_crd.yaml
+++ b/config/crd/bases/pulpproject_v1beta1_pulp_crd.yaml
@@ -73,6 +73,9 @@ spec:
                         type: boolean
                     type: object
                 type: object
+              bundle_cacert_secret:
+                description: Secret where the trusted Certificate Authority Bundle is stored
+                type: string
               sso_secret:
                   description: Secret where Single Sign-on configuration can be found
                   type: string

--- a/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
@@ -62,6 +62,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
+      - description: Secret where the trusted Certificate Authority Bundle is stored
+        path: bundle_cacert_secret
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:io.kubernetes:Secret
       - description: Configuration secret for SSO instance
         displayName: SSO configuration
         path: sso_secret

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -3,3 +3,4 @@ route_host: ''
 image_pull_secret: ''
 image_pull_secrets: []
 operator_service_account_name: '{{ lookup("env","OPERATOR_SA_NAME") | default("pulp-operator-sa",true) }}'
+bundle_cacert_secret: ''

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -45,3 +45,7 @@
     set_fact:
       web_url: "https://{{ route_host }}"
   when: ingress_type | lower == 'route'
+
+- name: Set Bundle Certificate Authority
+  include_tasks: set_bundle_cacert.yml
+  when: bundle_cacert_secret | length

--- a/roles/common/tasks/set_bundle_cacert.yml
+++ b/roles/common/tasks/set_bundle_cacert.yml
@@ -1,0 +1,15 @@
+---
+- name: Retrieve bundle Certificate Authority Secret
+  k8s_info:
+    kind: Secret
+    namespace: '{{ ansible_operator_meta.namespace }}'
+    name: '{{ bundle_cacert_secret }}'
+  register: bundle_cacert
+  no_log: "{{ no_log }}"
+
+- name: Load bundle Certificate Authority Secret content
+  set_fact:
+    bundle_ca_crt: '{{ bundle_cacert["resources"][0]["data"]["bundle-ca.crt"] | b64decode }}'
+  no_log: "{{ no_log }}"
+  when: '"bundle-ca.crt" in bundle_cacert["resources"][0]["data"]'
+...

--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -111,6 +111,16 @@ spec:
               - path: signing_service.asc
                 key: signing_service.asc
 {% endif %}
+{% if bundle_ca_crt is defined %}
+        - name: "ca-trust-extracted"
+          emptyDir: {}
+        - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+          secret:
+            secretName: "{{ bundle_cacert_secret }}"
+            items:
+              - key: bundle-ca.crt
+                path: 'bundle-ca.crt'
+{% endif %}
 {% if container_token_secret is defined %}
         - name: {{ ansible_operator_meta.name }}-container-auth-certs
           secret:
@@ -207,6 +217,14 @@ spec:
             - name: gpg-file-storage
               mountPath: "/var/lib/pulp/.gnupg"
 {% endif %}
+{% if bundle_ca_crt is defined %}
+            - name: "ca-trust-extracted"
+              mountPath: "/etc/pki/ca-trust/extracted"
+            - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+              mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+              subPath: bundle-ca.crt
+              readOnly: true
+{% endif %}
 {% endif %}
 {% if signing_secret is defined %}
             - name: {{ ansible_operator_meta.name }}-signing-scripts
@@ -236,8 +254,9 @@ spec:
               subPath: container_auth_public_key.pem
               readOnly: true
 {% endif %}
-{% if signing_secret is defined %}
+{% if signing_secret is defined or bundle_ca_crt is defined %}
       initContainers:
+{% if signing_secret is defined %}
         - name: gpg-importer
           image: "{{ gpg_init_container_image }}"
           imagePullPolicy: "{{ image_pull_policy }}"
@@ -273,4 +292,26 @@ spec:
               mountPath: "/etc/pulp/keys/signing_service.asc"
               subPath: signing_service.asc
               readOnly: true
+{% endif %}
+{% if bundle_ca_crt is defined %}
+        - name: configure-bundle-ca-cert
+          image: "{{ _image }}"
+          imagePullPolicy: "{{ image_pull_policy }}"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /etc/pki/ca-trust/extracted/{java,pem,openssl,edk2}
+              update-ca-trust
+{% if api.resource_requirements is defined %}
+          resources: {{ api.resource_requirements }}
+{% endif %}
+          volumeMounts:
+            - name: "ca-trust-extracted"
+              mountPath: "/etc/pki/ca-trust/extracted"
+            - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+              mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+              subPath: bundle-ca.crt
+              readOnly: true
+{% endif %}
 {% endif %}

--- a/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
@@ -88,6 +88,16 @@ spec:
               - path: signing_service.asc
                 key: signing_service.asc
 {% endif %}
+{% if bundle_ca_crt is defined %}
+        - name: "ca-trust-extracted"
+          emptyDir: {}
+        - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+          secret:
+            secretName: "{{ bundle_cacert_secret }}"
+            items:
+              - key: bundle-ca.crt
+                path: 'bundle-ca.crt'
+{% endif %}
 {% if is_file_storage %}
         - name: file-storage
           persistentVolumeClaim:
@@ -100,6 +110,28 @@ spec:
 {% if topology_spread_constraints %}
       topologySpreadConstraints:
         {{ topology_spread_constraints | indent(width=8) }}
+{% endif %}
+{% if bundle_ca_crt is defined %}
+      initContainers:
+        - name: configure-bundle-ca-cert
+          image: "{{ _image }}"
+          imagePullPolicy: "{{ image_pull_policy }}"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /etc/pki/ca-trust/extracted/{java,pem,openssl,edk2}
+              update-ca-trust
+{% if content.resource_requirements is defined %}
+          resources: {{ content.resource_requirements }}
+{% endif %}
+          volumeMounts:
+            - name: "ca-trust-extracted"
+              mountPath: "/etc/pki/ca-trust/extracted"
+            - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+              mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+              subPath: bundle-ca.crt
+              readOnly: true
 {% endif %}
       containers:
         - name: content
@@ -166,6 +198,14 @@ spec:
             - name: {{ ansible_operator_meta.name }}-signing-galaxy
               mountPath: "/etc/pulp/keys/signing_service.asc"
               subPath: signing_service.asc
+              readOnly: true
+{% endif %}
+{% if bundle_ca_crt is defined %}
+            - name: "ca-trust-extracted"
+              mountPath: "/etc/pki/ca-trust/extracted"
+            - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+              mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+              subPath: bundle-ca.crt
               readOnly: true
 {% endif %}
 {% if is_file_storage %}

--- a/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
+++ b/roles/pulp-worker/templates/pulp-worker.deployment.yaml.j2
@@ -96,6 +96,16 @@ spec:
               - path: signing_service.asc
                 key: signing_service.asc
 {% endif %}
+{% if bundle_ca_crt is defined %}
+        - name: "ca-trust-extracted"
+          emptyDir: {}
+        - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+          secret:
+            secretName: "{{ bundle_cacert_secret }}"
+            items:
+              - key: bundle-ca.crt
+                path: 'bundle-ca.crt'
+{% endif %}
 {% if is_file_storage %}
         - name: file-storage
           persistentVolumeClaim:
@@ -171,6 +181,14 @@ spec:
               subPath: signing_service.asc
               readOnly: true
 {% endif %}
+{% if bundle_ca_crt is defined %}
+            - name: "ca-trust-extracted"
+              mountPath: "/etc/pki/ca-trust/extracted"
+            - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+              mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+              subPath: bundle-ca.crt
+              readOnly: true
+{% endif %}
 {% if is_file_storage %}
             - name: file-storage
               readOnly: false
@@ -186,8 +204,9 @@ spec:
 {% if worker.resource_requirements is defined %}
           resources: {{ worker.resource_requirements }}
 {% endif %}
-{% if signing_secret is defined %}
+{% if signing_secret is defined or bundle_ca_crt is defined %}
       initContainers:
+{% if signing_secret is defined %}
         - name: gpg-importer
           image: "{{ gpg_init_container_image }}"
           imagePullPolicy: "{{ image_pull_policy }}"
@@ -223,4 +242,26 @@ spec:
               mountPath: "/etc/pulp/keys/signing_service.asc"
               subPath: signing_service.asc
               readOnly: true
+{% endif %}
+{% if bundle_ca_crt is defined %}
+        - name: configure-bundle-ca-cert
+          image: "{{ _image }}"
+          imagePullPolicy: "{{ image_pull_policy }}"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /etc/pki/ca-trust/extracted/{java,pem,openssl,edk2}
+              update-ca-trust
+{% if worker.resource_requirements is defined %}
+          resources: {{ worker.resource_requirements }}
+{% endif %}
+          volumeMounts:
+            - name: "ca-trust-extracted"
+              mountPath: "/etc/pki/ca-trust/extracted"
+            - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
+              mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+              subPath: bundle-ca.crt
+              readOnly: true
+{% endif %}
 {% endif %}


### PR DESCRIPTION
This adds a new parameter to the pulp CRD for specifying a secret resource that contains a bundle CA certificate value (under the `bundle-ca.crt` key.
The custom bundle CA certificate will be added to the trusted CA certificate database.
