### PR TITLE
Postgres Upgrade rescue needs to be in a block

### DIFF
--- a/roles/postgres/tasks/upgrade_postgres.yml
+++ b/roles/postgres/tasks/upgrade_postgres.yml
@@ -94,7 +94,7 @@
         - "postgres_pod['resources'][0]['status']['containerStatuses'][0]['ready'] == true"
       delay: 5
       retries: 60
-- rescue:
+  rescue:
     - name: Set error message
       set_fact:
         error_msg: "A Postgres {{ postgres_version }} Pod with the {{ postgres_label_selector }} label \


### PR DESCRIPTION
##### SUMMARY

When upgrade fails, the rescue block isn't executed because of a syntax error:

```
 TASK [Upgrade data dir from Postgres 12 to 13 if applicable] ******************************** 
[0;31mfatal: [localhost]: FAILED! => {"reason": "'rescue' keyword cannot be used without 'block'\n\nThe error appears to be in '/opt/ansible/roles/postgres/tasks/upgrade_postgres.yml': line 97, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n      retries: 60\n- rescue:\n  ^ here\n"}[0m
```

This fixes that.
