### PR TITLE
Always show deployment_name param for restore objects

### DIFF
--- a/bundle/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pulp-operator.clusterserviceversion.yaml
@@ -699,12 +699,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
-        - urn:alm:descriptor:com.tectonic.ui:text
       - displayName: API server configuration
         path: api
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: The number of API replicas.
+      - description: The number of API replicas
         displayName: Replicas
         path: api.replicas
         x-descriptors:

--- a/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
@@ -331,12 +331,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
-        - urn:alm:descriptor:io.kubernetes:StorageClass
       - displayName: API server configuration
         path: api
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
-      - description: The number of API replicas.
+      - description: The number of API replicas
         displayName: Replicas
         path: api.replicas
         x-descriptors:
@@ -671,7 +670,7 @@ spec:
       kind: PulpRestore
       name: pulprestores.pulp.pulpproject.org
       specDescriptors:
-      - displayName: Backup source to restore ?
+      - displayName: Backup source to restore from
         path: backup_source
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:select:CR
@@ -681,11 +680,10 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:backup_source:CR
-      - displayName: Deployment name
+      - displayName: New Deployment Name
         path: deployment_name
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:text
-        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:backup_source:PVC
       - displayName: Backup persistent volume claim
         path: backup_pvc
         x-descriptors:


### PR DESCRIPTION
##### SUMMARY

The deployment_name param should be required, and show always be shown, not just for PVC type.  


##### ADDITIONAL INFORMATION
 Currently, this is what happens:

![image](https://github.com/ansible/galaxy-operator/assets/11698892/9c57484c-2eb4-4a7c-ba97-dad1f08499a7)


And after merging:
![image](https://github.com/ansible/galaxy-operator/assets/11698892/5a3a799d-cd6d-4085-a089-81d79d41e716)
