### PR TITLE
During restore, only wait for the new deployment CR to be created

### DIFF
--- a/roles/restore/tasks/deploy_pulp.yml
+++ b/roles/restore/tasks/deploy_pulp.yml
@@ -81,9 +81,6 @@
     state: present
     definition: "{{ lookup('template', 'pulp_object.yaml.j2') }}"
     wait: true
-    wait_condition:
-      type: "{{ deployment_type|capitalize }}-Web-Ready"
-      status: "True"
 
 - name: Remove ownerReferences to prevent garbage collection of new CR
   k8s:


### PR DESCRIPTION
##### SUMMARY

Previously, we were waiting for the deployment to fully reconcile, which was just timing out and failing consistently.  With this change, it will only wait for the new deployment CR to be created.

This should merge along with these changes:
* https://github.com/ansible/galaxy-operator/pull/9

##### ADDITIONAL INFORMATION

```
The Galaxy object gets created, but the restore role waits until the galaxy object has fully reconciled and the web container is up.  It doesn't specify a custom wait_timeout, so the default of 120 is used, which is not nearly long enough.

^[[0;31m            "wait": true,^[[0m^M
^[[0;31m            "wait_condition": {^[[0m^M
^[[0;31m                "reason": null,^[[0m^M
^[[0;31m                "status": true,^[[0m^M
^[[0;31m                "type": "Automationhub-Web-Ready"^[[0m^M
^[[0;31m            },^[[0m^M
^[[0;31m            "wait_sleep": 5,^[[0m^M
^[[0;31m            "wait_timeout": 120^[[0m^M
```
