### PR TITLE
csv: Fix certificate authority typo

### DIFF
--- a/bundle/manifests/pulp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/pulp-operator.clusterserviceversion.yaml
@@ -832,7 +832,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - displayName: Certificate authorirty trust bundle
+      - displayName: Certificate authority trust bundle
         path: ca_trust_bundle
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced

--- a/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/pulp-operator.clusterserviceversion.yaml
@@ -464,7 +464,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
-      - displayName: Certificate authorirty trust bundle
+      - displayName: Certificate authority trust bundle
         path: ca_trust_bundle
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced


### PR DESCRIPTION
This replaces authorirty by authority.
