### PR TITLE
Set default-container for operator pod

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,7 +30,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: manager
+        kubectl.kubernetes.io/default-container: pulp-manager
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: pulp-operator


### PR DESCRIPTION
##### SUMMARY

Now when you try to view the logs from the operator pod, it will default to the operator container, rather than the kube-rbac-proxy container.
