### PR TITLE
updating start args and creating directories necessary for pulp

### DIFF
--- a/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
+++ b/roles/pulp-api/templates/pulp-api.deployment.yaml.j2
@@ -141,8 +141,7 @@ spec:
           image: "{{ _image }}"
           imagePullPolicy: "{{ image_pull_policy }}"
           # We set args, not command, so as to not override the entrypoint script
-          args:
-          - start-api
+          args: ["pulp-api"]
           lifecycle:
             postStart:
               exec:

--- a/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
+++ b/roles/pulp-content/templates/pulp-content.deployment.yaml.j2
@@ -138,8 +138,7 @@ spec:
           image: "{{ _image }}"
           imagePullPolicy: "{{ image_pull_policy }}"
           # We set args, not command, so as to not override the entrypoint script
-          args:
-          - start-content-app
+          args: ["pulp-content"]
           lifecycle:
             postStart:
               exec:


### PR DESCRIPTION
##### SUMMARY


The Pulp team removed the bit that pre-creates these directories in the start-up scripts, so we need to add them via the operator as a temporary measure until we can get this back in the Dockerfile (for galaxy-ng now since we are moving to those images).

This is where it was removed.

https://github.com/pulp/pulp-oci-images/commit/ee0d8be4303080234b124c86e2e370ada443ffbb#diff-761f9f30e489c48baf6aa471708506d271a0992ef396f40f694a7bb94911ce4eL3-L5

##### ADDITIONAL INFORMATION

See this comment for more information:
* https://github.com/ansible/galaxy-operator/pull/9#discussion_r1465852858