### PR TITLE
Include galaxy-ng nginx snippets and remove duplicate ones

### DIFF
--- a/roles/galaxy-web/defaults/main.yml
+++ b/roles/galaxy-web/defaults/main.yml
@@ -32,7 +32,7 @@ route_tls_secret: ''
 ca_trust_bundle: "/etc/pki/tls/certs/ca-bundle.crt"
 
 galaxy_webserver_static_dir: "/opt/app-root/src"
-galaxy_nginx_conf_dir: "/opt/app-root/etc/nginx.default.d"
+galaxy_nginx_conf_dir: "/app/galaxy_ng/app/webserver_snippets"
 
 # Here we use  _galaxy_ansible_com_galaxy to get un-modified cr
 # see: https://github.com/operator-framework/operator-sdk/issues/1770

--- a/roles/galaxy-web/templates/galaxy-web.configmap.yaml.j2
+++ b/roles/galaxy-web/templates/galaxy-web.configmap.yaml.j2
@@ -136,27 +136,5 @@ data:
                 proxy_pass http://galaxy-api;
                 # static files are served through whitenoise - http://whitenoise.evans.io/en/stable/
             }
-
-            location /ui/ {
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
-                proxy_set_header Host $http_host;
-                rewrite /ui* /static/galaxy_ng/index.html break;
-                # we don't want nginx trying to do something clever with
-                # redirects, we set the Host: header above already.
-                proxy_redirect off;
-                proxy_pass http://galaxy-api/static/galaxy_ng/index.html;
-            }
-
-            location /api/ {
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
-                proxy_set_header Host $http_host;
-                # we don't want nginx trying to do something clever with
-                # redirects, we set the Host: header above already.
-                proxy_redirect off;
-                proxy_pass http://galaxy-api;
-                client_max_body_size 0;
-            }
         }
     }


### PR DESCRIPTION
##### SUMMARY

Rather than maintain a separate copy of the nginx websnippets for galaxy /api/ and /ui/, we should use the ones already in the galaxy-ui image.

```
sh-4.4$ ls -la /app/galaxy_ng/app/webserver_snippets/
total 12
drwxrwxr-x. 1 default root   80 Feb 21 23:57 .
drwxrwxr-x. 1 default root   29 Feb 13 17:13 ..
-rw-r--r--. 1 root    root  795 Feb 15 18:30 galaxy_ng.conf
-rw-r--r--. 1 root    root  359 Feb 15 20:22 pulp_ansible.conf
-rw-r--r--. 1 root    root 1428 Feb 15 11:41 pulp_container.conf
sh-4.4$ cat /app/galaxy_ng/app/webserver_snippets/nginx.conf 
location /ui/ {
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Proto $scheme;
    proxy_set_header Host $http_host;
    rewrite /ui* /static/galaxy_ng/index.html break;
    # we don't want nginx trying to do something clever with
    # redirects, we set the Host: header above already.
    proxy_redirect off;
    proxy_pass http://pulp-api/static/galaxy_ng/index.html;
}

location /api/ {
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Proto $scheme;
    proxy_set_header Host $http_host;
    # we don't want nginx trying to do something clever with
    # redirects, we set the Host: header above already.
    proxy_redirect off;
    proxy_pass http://pulp-api/;
    client_max_body_size 0;
}
```
