### PR TITLE
Revert nginx conf

### DIFF
--- a/roles/galaxy-web/defaults/main.yml
+++ b/roles/galaxy-web/defaults/main.yml
@@ -32,7 +32,6 @@ route_tls_secret: ''
 ca_trust_bundle: "/etc/pki/tls/certs/ca-bundle.crt"
 
 galaxy_webserver_static_dir: "/opt/app-root/src"
-galaxy_nginx_conf_dir: "/opt/app-root/etc/nginx.default.d"
 
 # Here we use  _galaxy_ansible_com_galaxy to get un-modified cr
 # see: https://github.com/operator-framework/operator-sdk/issues/1770

--- a/roles/galaxy-web/templates/galaxy-web.configmap.yaml.j2
+++ b/roles/galaxy-web/templates/galaxy-web.configmap.yaml.j2
@@ -124,8 +124,6 @@ data:
                 proxy_pass http://galaxy-api;
             }
 
-            include {{ galaxy_nginx_conf_dir }}/*.conf;
-
             location / {
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
##### SUMMARY

Reverts this PR, which never worked - https://github.com/ansible/galaxy-operator/pull/51

Remove location entry, which would have included websnippets.  But they are not needed.  In fact, they don't exist upstream in the galaxy-ui image.  (they were part of the pulp-oci-images).