### PR TITLE
Install operator-sdk as needed for make targets

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -133,3 +133,16 @@ jobs:
       # - name: Debugging example (uncomment when needed)
       #   if: failure()
       #   uses: mxschmitt/action-tmate@v3
+
+  validate-bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # by default, it uses a depth of 1
+          # this fetches all history so that we can read each commit
+          fetch-depth: 0
+
+      - name: Validate OLM Bundle
+        run: VERSION=0.0.0 make bundle
+        shell: bash


### PR DESCRIPTION
##### SUMMARY
Install operator-sdk as needed for make targets
This also enables bundle validation checks on PR's.

