### PR TITLE
Use operator-sdk binary the make target lays down

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,14 +150,17 @@ jobs:
 
   validate-bundle:
     runs-on: ubuntu-latest
-    needs: [galaxy]
     steps:
       - uses: actions/checkout@v2
-        with:
-          # by default, it uses a depth of 1
-          # this fetches all history so that we can read each commit
-          fetch-depth: 0
+
+      # TODO: remove this step once the operator-sdk is available via the make operator-sdk target
+      - name: Install Operator SDK
+        run: |
+          VERSION=$(curl --silent "https://api.github.com/repos/operator-framework/operator-sdk/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+          curl -o operator-sdk -L https://github.com/operator-framework/operator-sdk/releases/download/${VERSION}/operator-sdk_linux_amd64
+          chmod +x operator-sdk
+          sudo mv operator-sdk /usr/local/bin/
 
       - name: Validate OLM Bundle
-        run: .ci/scripts/validate-bundle.sh
+        run: VERSION=0.0.0 make bundle
         shell: bash

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -138,10 +138,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          # by default, it uses a depth of 1
-          # this fetches all history so that we can read each commit
-          fetch-depth: 0
+
+      # TODO: remove this step once the operator-sdk is available via the make operator-sdk target
+      - name: Install Operator SDK
+        run: |
+          VERSION=$(curl --silent "https://api.github.com/repos/operator-framework/operator-sdk/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+          curl -o operator-sdk -L https://github.com/operator-framework/operator-sdk/releases/download/${VERSION}/operator-sdk_linux_amd64
+          chmod +x operator-sdk
+          sudo mv operator-sdk /usr/local/bin/
 
       - name: Validate OLM Bundle
         run: VERSION=0.0.0 make bundle


### PR DESCRIPTION
##### SUMMARY
[Install operator-sdk binary for use in CI workflows](https://github.com/ansible/galaxy-operator/pull/57/commits/266dcd6d65aa903d6f08ba0dfcdd10f6774f3146)

This should be done automatically by the `make operator-sdk` target, but this isn't working in the context of the GHA workflow for some reason.  Putting in this workaround for the time being.
