### PR TITLE
Always ensure /var/lib/pulp/media directory exists via the initContainer

### DIFF
--- a/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
+++ b/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
@@ -247,7 +247,12 @@ spec:
         - name: run-migrations
           image: {{ _image }}
           imagePullPolicy: '{{ image_pull_policy }}'
-          command: ['pulpcore-manager', 'migrate']
+          command:
+            - /bin/bash
+            - -c
+            - |
+              mkdir -p /var/lib/pulp/{tmp,media}
+              pulpcore-manager migrate
           env:
             - name: POSTGRES_SERVICE_HOST
               value: "{{ postgres_host }}"
@@ -264,6 +269,11 @@ spec:
               mountPath: "/etc/pulp/keys/database_fields.symmetric.key"
               subPath: database_fields.symmetric.key
               readOnly: true
+{% if is_file_storage %}
+            - name: file-storage
+              readOnly: false
+              mountPath: "/var/lib/pulp"
+{% endif %}
 {% if signing_secret is defined %}
         - name: gpg-importer
           image: "{{ _image }}"
@@ -274,7 +284,6 @@ spec:
             - -c
             - |
               cd /var/lib/pulp
-              mkdir -p /var/lib/pulp/{tmp,media}
               gpg --batch --import /etc/pulp/keys/signing_service.gpg
               echo "${PULP_SIGNING_KEY_FINGERPRINT}:6" | gpg --import-ownertrust
               output_col=$(PULP_WORKING_DIRECTORY=/tmp pulpcore-manager add-signing-service ${COLLECTION_SIGNING_SERVICE} /var/lib/pulp/scripts/collection_sign.sh ${PULP_SIGNING_KEY_FINGERPRINT} 2>&1)


### PR DESCRIPTION

##### SUMMARY

The  problem we were seeing is that if the signing secrets were _not_ configured, the gpg-importer container was never started.  So the command that pre-created that directory never gets run. As a result, we were getting these errors:

```
10.128.0.1 - - [23/Feb/2024:19:35:26 +0000] "GET /api/galaxy/pulp/api/v3/status/ HTTP/1.1" 200 1574 "-" "kube-probe/1.26"
pulp [3a626d4b6a464265bc036170e831c81e]: pulpcore.app.views.status:ERROR: Failed to determine disk usage
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/pulpcore/app/views/status.py", line 23, in _disk_usage
    return shutil.disk_usage(default_storage.location)
  File "/usr/lib64/python3.9/shutil.py", line 1295, in disk_usage
    st = os.statvfs(path)
FileNotFoundError: [Errno 2] No such file or directory: '/var/lib/pulp/media'
```

For the fix, it will be a noop if the directory already exists.  It will work whether there is a PVC backing the /var/lib/pulp directory or not.

