### PR TITLE
Fix conditional check for version input on stage workflow

### DIFF
--- a/.github/workflows/stage.yaml
+++ b/.github/workflows/stage.yaml
@@ -28,12 +28,12 @@ jobs:
         run: |
           set -e
 
-          if [[ ${{ github.event.inputs.confirm }} != "yes" ]]; then
+          if [ "${{ github.event.inputs.confirm }}" != "yes" ]; then
             >&2 echo "Confirm must be 'yes'"
             exit 1
           fi
 
-          if [[ ${{ github.event.inputs.version }} == "" ]]; then
+          if [ "${{ github.event.inputs.version }}" = "" ]; then
             >&2 echo "No version specified. A cal-version will be generated."
           fi
 


### PR DESCRIPTION
##### SUMMARY
Should be `=`, not `==`. 

When running the stage.yml workflow, I see:

```
/home/runner/work/_temp/b6973b0b-905e-4409-a600-a3a2227b69f2.sh: line 8: conditional binary operator expected
```
