### PR TITLE
Break calver generation into a dedicated python script

### DIFF
--- a/.ci/scripts/generate-cal-version.py
+++ b/.ci/scripts/generate-cal-version.py
@@ -1,0 +1,22 @@
+# generate_version.py
+import requests
+import datetime
+import os
+
+version = os.getenv('INPUT_VERSION')
+gh_repo = os.getenv('GH_REPO')
+
+response = requests.get(f'https://api.github.com/repos/{gh_repo}/releases')
+releases = [release['tag_name'] for release in response.json()]
+if version in releases:
+    raise ValueError(f"A release with version {version} already exists.")
+
+if not version:
+    date = datetime.datetime.now().strftime('%Y.%m.%d')
+    version = date
+    suffix = 2
+    while version in releases:
+        version = f'{date}-{suffix}'
+        suffix += 1
+
+print(version)

--- a/.github/workflows/stage.yaml
+++ b/.github/workflows/stage.yaml
@@ -59,25 +59,10 @@ jobs:
 
       - name: Generate CalVer and create release
         id: generate_version
-        run: |
-          import requests
-          import datetime
-          import os
-
-          version = os.getenv('INPUT_VERSION')
-          if not version:
-              date = datetime.datetime.now().strftime('%Y.%m.%d')
-              version = date
-              response = requests.get('https://api.github.com/repos/${{ github.repository }}/releases')
-              releases = [release['tag_name'] for release in response.json()]
-              suffix = 2
-              while version in releases:
-                  version = f'{date}-{suffix}'
-                  suffix += 1
-
-          echo "::set-output name=version::${version}"
+        run: python generate_version.py
         env:
           INPUT_VERSION: ${{ github.event.inputs.version }}
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log into registry ghcr.io


### PR DESCRIPTION
##### SUMMARY

GHA  took issue with me running this as an in-line script, giving me the following error:

```
import-im6.q16: unable to open X server `' @ error/import.c/ImportImageCommand/346.
```
My best guess is that it is stumbling over the python import lines because of a name conflict with "import" and whatever tool GHA uses to run workflows in containers.  

So I am breaking the script out into a dedicated file as it should have been in the first place. 

I also improved the script to error if the input_version from the user is already a release.

##### ADDITIONAL INFORMATION

This passes all of my test cases below:

```bash
$ GH_REPO=ansible/galaxy-operator INPUT_VERSION='0.15.0' python3 generate-cal-version.py
Traceback (most recent call last):
  File "/home/chadams/galaxy-operator/.ci/scripts/generate-cal-version.py", line 12, in <module>
    raise ValueError(f"A release with version {version} already exists.")
ValueError: A release with version 0.15.0 already exists.

$ GH_REPO=ansible/galaxy-operator INPUT_VERSION='0.15.1' python3 generate-cal-version.py
0.15.1

$ GH_REPO=ansible/galaxy-operator python3 generate-cal-version.py
2024.02.29

$ GH_REPO=ansible/galaxy-operator INPUT_VERSION='' python3 generate-cal-version.py
2024.02.29
```