### PR TITLE
setting README image source to full url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/images/logo_large.svg" style="width: 55%" />
+  <img src="https://raw.githubusercontent.com/ansible/galaxy-operator/main/docs/images/logo_large.svg" style="width: 55%" />
 </p>
 
 # Galaxy-Operator


### PR DESCRIPTION
The README and readthedocs were having trouble resolving the image from the same location so to avoid this I just set the full url path in the README which SHOULD work everywhere.