### PR TITLE
fix: add missing nginx snippets for pulp_container

### DIFF
--- a/roles/galaxy-web/templates/galaxy-web.configmap.yaml.j2
+++ b/roles/galaxy-web/templates/galaxy-web.configmap.yaml.j2
@@ -156,5 +156,26 @@ data:
                 proxy_pass http://galaxy-api;
                 client_max_body_size 0;
             }
+
+            location /v2/ {
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header Host $http_host;
+                # we don't want nginx trying to do something clever with
+                # redirects, we set the Host: header above already.
+                proxy_redirect off;
+                proxy_pass http://galaxy-api;
+                client_max_body_size 0;
+            }
+
+            location /pulp/container/ {
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header Host $http_host;
+                # we don't want nginx trying to do something clever with
+                # redirects, we set the Host: header above already.
+                proxy_redirect off;
+                proxy_pass http://galaxy-content;
+            }
         }
     }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Closes #74 

Add missing following two snippets for configmap for nginx.conf:

- `location /v2/` with `client_max_body_size 0;`
- `location /pulp/container/` with `proxy_pass http://galaxy-content;`

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Tested by deploying customize Operator:

```bash
$ IMG=registry.example.com/ansible/galaxy-operator:nginx-v2 make docker-build docker-push deploy
```

After customized Operator is up and running, I can confirm `docker push` works as expeted.

```bash
$ docker push galaxy.example.com/ansible/awx-operator:latest
The push refers to repository [galaxy.example.com/ansible/awx-operator]
8a781877ae2d: Layer already exists 
50249f417f60: Layer already exists 
308817e4fc18: Layer already exists 
159f14b224e2: Layer already exists 
d4a2fce0f4ab: Layer already exists 
5be6a5d3fc93: Pushed 
e611347a452f: Pushed 
5f70bf18a086: Pushed 
2f9e60689d2b: Pushed 
70df77fd1c09: Pushed 
4db72d16bb63: Pushed 
d7082a8129ea: Pushed 
6615b78892ea: Pushed 
64042e60a2a6: Pushed 
62329031ba4e: Pushed 
86426b9e591d: Pushed 
latest: digest: sha256:f2905050e3ac1821d6f6753dd4a649aa7db03f2da5425f056033aeaf3e7cc809 size: 3665
```
