### PR TITLE
docs: enable search feature

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -83,9 +83,9 @@ plugins:
             - url: https://docs.ansible.com/ansible/latest/objects.inv
               domains: [py, std]
   - git-revision-date
-  - search:
+  - material/search:
       lang: en
-      prebuild_index: true
+      separator: '[\s\-,:!=\[\]()"`/]+|\.(?!\d)|&[lg]t;|(?!\b)(?=[A-Z][a-z])'
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
As follow-up for #69, this PR enables search feature by using built-in `search` plugin from Material theme.

![image](https://github.com/ansible/galaxy-operator/assets/2920259/0bbd27bf-ab7e-4bba-a97a-e307ad162ab9)

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

@aknochow 
F.Y.I., [just adding `search.*` to `features`](https://github.com/ansible/galaxy-operator/pull/69/files#diff-57381c8acc17df6530456c578e76d03d4a1cb287f7edd980502b4a9cedb9524dR18-R20) is not enough to enable search feature. 

Please refer to my comment on the PR on AWX Operator repo to further information for the changes I made in this PR: https://github.com/ansible/awx-operator/pull/1725#discussion_r1498621721
See also: https://github.com/ansible/mkdocs-ansible/blob/main/mkdocs.yml