### PR TITLE
feat: add missing snippets for nginx

### DIFF
--- a/roles/galaxy-web/defaults/main.yml
+++ b/roles/galaxy-web/defaults/main.yml
@@ -25,6 +25,7 @@ route_tls_secret: ''
 ca_trust_bundle: "/etc/pki/tls/certs/ca-bundle.crt"
 
 galaxy_webserver_static_dir: "/opt/app-root/src"
+galaxy_nginx_conf_dir: "/etc/nginx/default.d"
 
 # Here we use  _galaxy_ansible_com_galaxy to get un-modified cr
 # see: https://github.com/operator-framework/operator-sdk/issues/1770

--- a/roles/galaxy-web/templates/galaxy-web.configmap.yaml.j2
+++ b/roles/galaxy-web/templates/galaxy-web.configmap.yaml.j2
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: '{{ deployment_type }}'
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
 data:
-  nginx_conf: |
+  nginx.conf: |
     error_log /dev/stdout info;
     worker_processes 1;
     events {
@@ -30,11 +30,11 @@ data:
         # to build optimal hash types.
         types_hash_max_size 4096;
 
-        upstream galaxy-content {
+        upstream pulp-content {
             server {{ ansible_operator_meta.name }}-content-svc:24816;
         }
 
-        upstream galaxy-api {
+        upstream pulp-api {
             server {{ ansible_operator_meta.name }}-api-svc:8000;
         }
 
@@ -101,7 +101,7 @@ data:
                 # we don't want nginx trying to do something clever with
                 # redirects, we set the Host: header above already.
                 proxy_redirect off;
-                proxy_pass http://galaxy-content;
+                proxy_pass http://pulp-content;
             }
 
             location {{ pulp_combined_settings.api_root }}api/v3/ {
@@ -111,7 +111,7 @@ data:
                 # we don't want nginx trying to do something clever with
                 # redirects, we set the Host: header above already.
                 proxy_redirect off;
-                proxy_pass http://galaxy-api;
+                proxy_pass http://pulp-api;
             }
 
             location /auth/login/ {
@@ -121,8 +121,10 @@ data:
                 # we don't want nginx trying to do something clever with
                 # redirects, we set the Host: header above already.
                 proxy_redirect off;
-                proxy_pass http://galaxy-api;
+                proxy_pass http://pulp-api;
             }
+
+            include {{ galaxy_nginx_conf_dir }}/*.conf;
 
             location / {
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -131,51 +133,87 @@ data:
                 # we don't want nginx trying to do something clever with
                 # redirects, we set the Host: header above already.
                 proxy_redirect off;
-                proxy_pass http://galaxy-api;
+                proxy_pass http://pulp-api;
                 # static files are served through whitenoise - http://whitenoise.evans.io/en/stable/
             }
-
-            location /ui/ {
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
-                proxy_set_header Host $http_host;
-                rewrite /ui* /static/galaxy_ng/index.html break;
-                # we don't want nginx trying to do something clever with
-                # redirects, we set the Host: header above already.
-                proxy_redirect off;
-                proxy_pass http://galaxy-api/static/galaxy_ng/index.html;
-            }
-
-            location /api/ {
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
-                proxy_set_header Host $http_host;
-                # we don't want nginx trying to do something clever with
-                # redirects, we set the Host: header above already.
-                proxy_redirect off;
-                proxy_pass http://galaxy-api;
-                client_max_body_size 0;
-            }
-
-            location /v2/ {
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
-                proxy_set_header Host $http_host;
-                # we don't want nginx trying to do something clever with
-                # redirects, we set the Host: header above already.
-                proxy_redirect off;
-                proxy_pass http://galaxy-api;
-                client_max_body_size 0;
-            }
-
-            location /pulp/container/ {
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
-                proxy_set_header Host $http_host;
-                # we don't want nginx trying to do something clever with
-                # redirects, we set the Host: header above already.
-                proxy_redirect off;
-                proxy_pass http://galaxy-content;
-            }
         }
+    }
+
+  # https://github.com/ansible/galaxy_ng/blob/master/galaxy_ng/app/webserver_snippets/nginx.conf
+  galaxy_ng.conf: |
+    location /ui/ {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
+        rewrite /ui* /static/galaxy_ng/index.html break;
+        # we don't want nginx trying to do something clever with
+        # redirects, we set the Host: header above already.
+        proxy_redirect off;
+        proxy_pass http://pulp-api/static/galaxy_ng/index.html;
+    }
+
+    location /api/ {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
+        # we don't want nginx trying to do something clever with
+        # redirects, we set the Host: header above already.
+        proxy_redirect off;
+        proxy_pass http://pulp-api;
+        client_max_body_size 0;
+    }
+
+  # https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/webserver_snippets/nginx.conf
+  pulp_ansible.conf: |
+    location /pulp_ansible/galaxy/ {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
+        # we don't want nginx trying to do something clever with
+        # redirects, we set the Host: header above already.
+        proxy_redirect off;
+        proxy_pass http://pulp-api;
+    }
+
+  # https://github.com/pulp/pulp_container/blob/main/pulp_container/app/webserver_snippets/nginx.conf
+  pulp_container.conf: |
+    location /v2/ {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
+        # we don't want nginx trying to do something clever with
+        # redirects, we set the Host: header above already.
+        proxy_redirect off;
+        proxy_pass http://pulp-api;
+        client_max_body_size 0;
+    }
+
+    location /extensions/v2/ {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
+        # we don't want nginx trying to do something clever with
+        # redirects, we set the Host: header above already.
+        proxy_redirect off;
+        proxy_pass http://pulp-api;
+    }
+
+    location /pulp/container/ {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
+        # we don't want nginx trying to do something clever with
+        # redirects, we set the Host: header above already.
+        proxy_redirect off;
+        proxy_pass http://pulp-content;
+    }
+
+    location /token/ {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
+        # we don't want nginx trying to do something clever with
+        # redirects, we set the Host: header above already.
+        proxy_redirect off;
+        proxy_pass http://pulp-api;
     }

--- a/roles/galaxy-web/templates/galaxy-web.deployment.yaml.j2
+++ b/roles/galaxy-web/templates/galaxy-web.deployment.yaml.j2
@@ -70,6 +70,18 @@ spec:
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
               readOnly: true
+            - name: {{ ansible_operator_meta.name }}-nginx-conf
+              mountPath: {{ galaxy_nginx_conf_dir }}/galaxy_ng.conf
+              subPath: galaxy_ng.conf
+              readOnly: true
+            - name: {{ ansible_operator_meta.name }}-nginx-conf
+              mountPath: {{ galaxy_nginx_conf_dir }}/pulp_ansible.conf
+              subPath: pulp_ansible.conf
+              readOnly: true
+            - name: {{ ansible_operator_meta.name }}-nginx-conf
+              mountPath: {{ galaxy_nginx_conf_dir }}/pulp_container.conf
+              subPath: pulp_container.conf
+              readOnly: true
 {% if ingress_type | lower == 'route' and route_tls_termination_mechanism | lower == 'passthrough' %}
             - name: "{{ ansible_operator_meta.name }}-nginx-certs"
               mountPath: "/etc/nginx/pki"
@@ -124,9 +136,6 @@ spec:
         - name: {{ ansible_operator_meta.name }}-nginx-conf
           configMap:
             name: '{{ ansible_operator_meta.name }}-{{ deployment_type }}-configmap'
-            items:
-              - key: nginx_conf
-                path: nginx.conf
 {% if ingress_type | lower == 'route' and route_tls_termination_mechanism | lower == 'passthrough' %}
         - name: "{{ ansible_operator_meta.name }}-nginx-certs"
           secret:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Closes #77, but if you have a better way, feel free to close this PR and open new one 😃 

Changes:

- Rename `upstream` directives; `galaxy-*` to `pulp-*`, to use snippets as they are
- Rename keys in configmap from `*_conf` to `*.conf` to simplify `volumes`
- Add following three snippets as dedicated keys for each files under the same configmap
  - [galaxy_ng.conf](https://github.com/ansible/galaxy_ng/blob/master/galaxy_ng/app/webserver_snippets/nginx.conf)
  - [pulp_ansible.conf](https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/webserver_snippets/nginx.conf)
  - [pulp_container.conf](https://github.com/pulp/pulp_container/blob/main/pulp_container/app/webserver_snippets/nginx.conf)
- Mount above snippets under `/etc/nginx/default.d`
- Add `include` to main `nginx.conf` to include snippets
- Remove duplicated `location` directives from main `nginx.conf` to use snippets as they are

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

I can confirm that:

- Upadted `nginx.conf` and new snippets are available on desired path
- UI is accessible
- Container image can be pushed

<!--- Paste verbatim command output below, e.g. before and after your change -->
```bash
$ kubectl -n galaxy exec deployment/galaxy-web -c web -- cat /etc/nginx/nginx.conf
...
http {
    ...
    server {
        ...

        include /etc/nginx/default.d/*.conf;

        location / {
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header X-Forwarded-Proto $scheme;
            proxy_set_header Host $http_host;
            # we don't want nginx trying to do something clever with
            # redirects, we set the Host: header above already.
            proxy_redirect off;
            proxy_pass http://pulp-api;
            # static files are served through whitenoise - http://whitenoise.evans.io/en/stable/
        }
    }
}
```

```bash
$ kubectl -n galaxy exec deployment/galaxy-web -c web -- ls -l /etc/nginx/default.d
total 12
-rw-r--r--. 1 root root  795 Mar  5 12:46 galaxy_ng.conf
-rw-r--r--. 1 root root  359 Mar  5 12:46 pulp_ansible.conf
-rw-r--r--. 1 root root 1429 Mar  5 12:46 pulp_container.conf
```

```bash
$ kubectl -n galaxy exec deployment/galaxy-web -c web -- cat /etc/nginx/default.d/galaxy_ng.conf
location /ui/ {
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Proto $scheme;
    proxy_set_header Host $http_host;
    rewrite /ui* /static/galaxy_ng/index.html break;
    # we don't want nginx trying to do something clever with
    # redirects, we set the Host: header above already.
    proxy_redirect off;
    proxy_pass http://pulp-api/static/galaxy_ng/index.html;
}

location /api/ {
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Proto $scheme;
    proxy_set_header Host $http_host;
    # we don't want nginx trying to do something clever with
    # redirects, we set the Host: header above already.
    proxy_redirect off;
    proxy_pass http://pulp-api;
    client_max_body_size 0;
}
```