### PR TITLE
Set reasonable default GHA timeout values values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   galaxy:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -150,6 +151,7 @@ jobs:
 
   validate-bundle:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,7 @@ env:
 jobs:
   galaxy:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -136,6 +137,7 @@ jobs:
 
   validate-bundle:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
##### SUMMARY

If CI takes longer than 30 minutes to run, there is probably an issue, we should fail early rather than wasting more GHA minutes.  This also has the added bonus of the logs not being so long that they don't load in the GitHub UI.  