### PR TITLE
Pin pulp-cli to 0.23.0 for CI temporarily

### DIFF
--- a/.ci/scripts/backup_and_restore.sh
+++ b/.ci/scripts/backup_and_restore.sh
@@ -76,7 +76,7 @@ echo $BASE_ADDR
 
 if [ -z "$(pip freeze | grep pulp-cli)" ]; then
   echo "Installing pulp-cli"
-  pip install pulp-cli[pygments]
+  pip install pulp-cli[pygments]==0.23.0
 fi
 
 if [[ "$CI_TEST" == "galaxy" ]]; then

--- a/.ci/scripts/galaxy_tests.sh
+++ b/.ci/scripts/galaxy_tests.sh
@@ -24,7 +24,7 @@ password password\
 export BASE_ADDR="http://$SERVER:$WEB_PORT"
 echo $BASE_ADDR
 
-pip install pulp-cli
+pip install pulp-cli==0.23.0
 
 if [ ! -f ~/.config/pulp/settings.toml ]; then
   echo "Configuring pulp-cli"


### PR DESCRIPTION
##### SUMMARY

The recent pulp-cli 0.24.0 release seems to have broken CI
* https://pypi.org/project/pulp-cli/