### PR TITLE
fix: correct issue with bundle_cacert_secret in api template

### DIFF
--- a/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
+++ b/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
@@ -95,7 +95,7 @@ spec:
               - path: collection_sign.sh
                 key: collection_sign.sh
               - path: container_sign.sh
-                key: container_sign.sh            
+                key: container_sign.sh
         - name: {{ ansible_operator_meta.name }}-signing-galaxy
           secret:
             secretName: {{ signing_secret }}
@@ -212,6 +212,7 @@ spec:
             - name: gpg-file-storage
               mountPath: "/var/lib/pulp/.gnupg"
 {% endif %}
+{% endif %}
 {% if bundle_ca_crt is defined %}
             - name: "ca-trust-extracted"
               mountPath: "/etc/pki/ca-trust/extracted"
@@ -219,7 +220,6 @@ spec:
               mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
               subPath: bundle-ca.crt
               readOnly: true
-{% endif %}
 {% endif %}
 {% if signing_secret is defined %}
             - name: {{ ansible_operator_meta.name }}-signing-scripts


### PR DESCRIPTION
##### SUMMARY

There is a bug within one of the deployment templates where the `bundle_ca_crt` block is wrapped within the `is_file_storage` block. So in order for the `bundle_ca_crt` to occur, then `is_file_storage` needs to be false. I couldn't get this variable to be false on a normal deployment of Automation Hub.

```
{% if is_file_storage %}
            - name: file-storage
              readOnly: false
              mountPath: "/var/lib/pulp"
{% else %}
            - name: tmp-file-storage
              mountPath: "/var/lib/pulp/tmp"
            - name: assets-file-storage
              mountPath: "/var/lib/pulp/assets"
{% if signing_secret is defined %}
            - name: gpg-file-storage
              mountPath: "/var/lib/pulp/.gnupg"
{% endif %}
{% if bundle_ca_crt is defined %}
            - name: "ca-trust-extracted"
              mountPath: "/etc/pki/ca-trust/extracted"
            - name: "{{ ansible_operator_meta.name }}-bundle-cacert"
              mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
              subPath: bundle-ca.crt
              readOnly: true
{% endif %}
{% endif %}
```

##### ADDITIONAL INFORMATION

Bug Report: https://issues.redhat.com/browse/AAP-22066
