### PR TITLE
Makefile: Fix catalog-push with podman engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ catalog-build: opm ## Build a catalog image.
 # Push the catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
-	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+	$(MAKE) $(ENGINE)-push IMG=$(CATALOG_IMG)
 
 # Generate operator.yaml with image tag as a release artifact
 .PHONY: generate-operator-yaml


### PR DESCRIPTION
##### SUMMARY
When using podman as engine for pushing the catalog index then it's still using docker rather than the podman target

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
