### PR TITLE
Remove invalid main image tags from samples

### DIFF
--- a/config/samples/galaxy_v1beta1_galaxy_cr.ci.yaml
+++ b/config/samples/galaxy_v1beta1_galaxy_cr.ci.yaml
@@ -3,8 +3,6 @@ kind: Galaxy
 metadata:
   name: example-galaxy
 spec:
-  image_version: main
-  image_web_version: main
   no_log: false
   admin_password_secret: "example-galaxy-admin-password"
   storage_type: File


### PR DESCRIPTION
##### SUMMARY

`main` tag does not exist on https://quay.io/repository/ansible/galaxy-ng?tab=tags&tag=latest
