### PR TITLE
Make calver versions compatible with semver for bundle commands

### DIFF
--- a/.ci/scripts/generate-cal-version.py
+++ b/.ci/scripts/generate-cal-version.py
@@ -12,11 +12,11 @@ if version in releases:
     raise ValueError(f"A release with version {version} already exists.")
 
 if not version:
-    date = datetime.datetime.now().strftime('%Y.%m.%d')
-    version = date
+    date = datetime.datetime.now()
+    version = f'{date.year}.{date.month}.{date.day}'
     suffix = 2
     while version in releases:
-        version = f'{date}-{suffix}'
+        version = f'{date.year}.{date.month}.{date.day}-{suffix}'
         suffix += 1
 
 print(version)


### PR DESCRIPTION
##### SUMMARY


The release workflow currently fails because the calver version is not semver compatible:

```
Run make bundle bundle-build IMG=galaxy-operator:${TAG_NAME} VERSION=${TAG_NAME} BUNDLE_IMG=galaxy-operator-bundle:${TAG_NAME}
/usr/local/bin/operator-sdk generate kustomize manifests -q
cd config/manager && /usr/local/bin/kustomize edit set image controller=galaxy-operator:2024.04.03
/usr/local/bin/kustomize build config/manifests | /usr/local/bin/operator-sdk generate bundle -q --overwrite --version 2024.04.03 --channels="alpha" --default-channel="alpha"
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
Error: invalid command options: 2024.04.03 is not a valid semantic version: Minor number must not contain leading zeroes "04"
```

After this change, the leading zeros are gone and it is compatible.

```
$ GH_REPO=ansible/galaxy-operator python generate-cal-version.py 
2024.4.3
```
