### PR TITLE
Use docker engine for container build make targets in release GHA

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,8 @@
 name: Promote Operator Release
 
+env:
+  ENGINE: docker # use docker for everything so buildx commands can be used
+
 on:
   release:
     types: [published]
@@ -72,7 +75,7 @@ jobs:
 
       - name: Build Bundle Image
         run: |
-          make bundle bundle-build IMG=galaxy-operator:${TAG_NAME} VERSION=${TAG_NAME} BUNDLE_IMG=galaxy-operator-bundle:${TAG_NAME}
+          make bundle bundle-build IMG=quay.io/ansible/galaxy-operator:${TAG_NAME} VERSION=${TAG_NAME} BUNDLE_IMG=galaxy-operator-bundle:${TAG_NAME}
           docker tag galaxy-operator-bundle:${TAG_NAME} galaxy-operator-bundle:latest
         working-directory: galaxy-operator
 


### PR DESCRIPTION
- engine defaults to podman, but podman does not support all docker buildx features at the moment
- for now, we can solve this by using docker everywhere in this workflow
- fix galaxy-operator image refs in CSV

##### SUMMARY

tl;dr, there were a lot of issues with our promotion GHA workflow, they are now all resolved with this PR, evidenced by the successful release of 20.24.4.3:
* https://github.com/ansible/galaxy-operator/releases/tag/2024.4.3
* stage pipeline - https://github.com/ansible/galaxy-operator/actions/runs/8546049172
* promote pipeline - https://github.com/ansible/galaxy-operator/actions/runs/8557642616

