### PR TITLE
restore: Move storage_claim fact

### DIFF
--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -40,10 +40,6 @@
   when: postgres_label_selector is not defined
 
 - block:
-    - name: Set the resource pod name as a variable.
-      set_fact:
-        storage_claim: "{{ deployment_name }}-file-storage"
-
     - name: Get the postgres pod information
       k8s_info:
         kind: Pod
@@ -64,6 +60,10 @@
   when: postgres_type == 'managed'
 
 - block:
+    - name: Set the resource pod name as a variable.
+      set_fact:
+        storage_claim: "{{ deployment_name }}-file-storage"
+
     - name: Wait for PVC to be created if file-storage is used
       k8s_info:
         api_version: v1


### PR DESCRIPTION
##### SUMMARY

The current storage_claim fact is set in the block when the database is managed by the operator but that variable is used for the file storage PVC.
When using an external database then that fact isn't set and the next block statement about the PVC information fails

This was introduced during the backup/restore refact in 4ca8436e

##### ADDITIONAL INFORMATION

```
TASK [Wait for PVC to be created if file-storage is used] ********************************
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'storage_claim' is undefined\n\nThe error appears to be in '/opt/ansible/roles/restore/tasks/postgres.yml': line 68, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n- block:\n - name: Wait for PVC to be created if file-storage is used\n ^ here\n"}
...ignoring
TASK [Fail with custom message if PVC not found] ********************************
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'pvc_status.resources | length == 0' failed. The error was: error while evaluating conditional (pvc_status.resources | length == 0): 'dict object' has no attribute 'resources'\n\nThe error appears to be in '/opt/ansible/roles/restore/tasks/postgres.yml': line 80, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n - name: Fail with custom message if PVC not found\n ^ here\n"}
```