### PR TITLE
patchesStrategicMerge is deprecated updating to patches

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -20,7 +20,7 @@ resources:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -20,12 +20,10 @@ resources:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
-
-# Mount the controller config file for loading manager configurations
-# through a ComponentConfig type
-#- manager_config_patch.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+- path: manager_auth_proxy_patch.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -27,3 +27,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 patches:
 - path: manager_auth_proxy_patch.yaml
+
+# Mount the controller config file for loading manager configurations
+# through a ComponentConfig type
+#- manager_config_patch.yaml


### PR DESCRIPTION
##### SUMMARY
when trying to deploy the operator on a k3s instance I was getting an error saying "patchesStrategicMerge is deprecated. Please use patches" I used the command 'kustomize edit fix' and it updated the file to look like this

