### PR TITLE
fix: make undeploy to respect user-provided namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ deploy: kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/c
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
+	cd config/default && $(KUSTOMIZE) edit set namespace ${NAMESPACE}
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
 resources: kustomize ## Get galaxy resources


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Allow users to specify non-default `NAMESPACE` for `make undeploy`

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->


##### ORIGINAL ISSUE

The command `NAMESPACE=awesomegalaxy make undeploy` does not works as expected after `git checkout .`.

```bash
# Deploy Operator on `awesomegalaxy` namespace
$ NAMESPACE=awesomegalaxy make deploy
cd config/manager && /home/kuro/work/kurokobo/galaxy-operator/bin/kustomize edit set image controller=quay.io/ansible/galaxy-operator:2024.4.3-10-ga21c706
cd config/default && /home/kuro/work/kurokobo/galaxy-operator/bin/kustomize edit set namespace awesomegalaxy
/home/kuro/work/kurokobo/galaxy-operator/bin/kustomize build config/default | kubectl apply -f -
namespace/awesomegalaxy created
...

# Revert local changes
$ git checkout .
Updated 2 paths from the index

# Try to undeploy everything on `awesomegalaxy` namespace, but `NAMESPACE=awesomegalaxy` is ignored
$ NAMESPACE=awesomegalaxy make undeploy
/home/kuro/work/kurokobo/galaxy-operator/bin/kustomize build config/default | kubectl delete -f -
customresourcedefinition.apiextensions.k8s.io "galaxies.galaxy.ansible.com" deleted
customresourcedefinition.apiextensions.k8s.io "galaxybackups.galaxy.ansible.com" deleted
customresourcedefinition.apiextensions.k8s.io "galaxyrestores.galaxy.ansible.com" deleted
clusterrole.rbac.authorization.k8s.io "galaxy-operator-galaxy-operator-cluster-role" deleted
clusterrole.rbac.authorization.k8s.io "galaxy-operator-metrics-reader" deleted
clusterrolebinding.rbac.authorization.k8s.io "galaxy-operator-galaxy-operator-cluster-rolebinding" deleted
Error from server (NotFound): error when deleting "STDIN": namespaces "galaxy" not found     ✅
...
make: *** [Makefile:140: undeploy] Error 1
```

##### ADDITIONAL INFORMATION

Test:

```bash
$ NAMESPACE=awesomegalaxy make deploy
cd config/manager && /home/kuro/work/kurokobo/galaxy-operator/bin/kustomize edit set image controller=quay.io/ansible/galaxy-operator:2024.4.3-11-g81c8d45
cd config/default && /home/kuro/work/kurokobo/galaxy-operator/bin/kustomize edit set namespace awesomegalaxy
/home/kuro/work/kurokobo/galaxy-operator/bin/kustomize build config/default | kubectl apply -f -
namespace/awesomegalaxy created
...

$ git checkout .
Updated 2 paths from the index

$ NAMESPACE=awesomegalaxy make undeploy
cd config/default && /home/kuro/work/kurokobo/galaxy-operator/bin/kustomize edit set namespace awesomegalaxy
/home/kuro/work/kurokobo/galaxy-operator/bin/kustomize build config/default | kubectl delete -f -
namespace "awesomegalaxy" deleted     ✅
...
```