### PR TITLE
fixing signing-secret backup

### DIFF
--- a/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
@@ -912,6 +912,9 @@ spec:
               upgradedPostgresVersion:
                 description: Status to indicate that the database has been upgraded to the version in the status
                 type: string
+              signingSecret:
+                description: Secret where the signing certificates are stored
+                type: string
               conditions:
                 description: The resulting conditions when a Service Telemetry is instantiated
                 items:

--- a/roles/backup/templates/backup-content-k8s-job.yaml.j2
+++ b/roles/backup/templates/backup-content-k8s-job.yaml.j2
@@ -28,8 +28,8 @@ spec:
           - /bin/bash
           - -c
           - |
-            mkdir -p {{ _backup_dir }}/pulp/
-            cp -fr /var/lib/pulp/. {{ _backup_dir }}/pulp
+            mkdir -p {{ _backup_dir }}/pulp
+            cp -fr /var/lib/pulp/{artifact,media,scripts} {{ _backup_dir }}/pulp/
 {% if backup_resource_requirements is defined %}
         resources:
           {{ backup_resource_requirements | to_nice_yaml(indent=2) | indent(width=10, first=False) }}

--- a/roles/restore/templates/restore-content-k8s-job.yaml.j2
+++ b/roles/restore/templates/restore-content-k8s-job.yaml.j2
@@ -28,8 +28,8 @@ spec:
           - /bin/bash
           - -c
           - |
-            stat {{ backup_dir }}/pulp/
-            cp -fr {{ backup_dir }}/pulp/. /var/lib/pulp
+            stat {{ backup_dir }}/pulp
+            cp -fr {{ backup_dir }}/pulp /var/lib/pulp
 {% if restore_resource_requirements is defined %}
         resources:
           {{ restore_resource_requirements | to_nice_yaml(indent=2) | indent(width=10, first=False) }}


### PR DESCRIPTION
##### SUMMARY

Fixes Backups to include the signing secret.

Explicitly set directories in /var/lib/pulp/ to avoid permissions issues with .gnupg directory.