### PR TITLE
fixing signing scripts and configmap to use user-provided names

### DIFF
--- a/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
+++ b/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
@@ -91,7 +91,7 @@ spec:
         - name: tmp-emptydir
           emptyDir: {}
 {% if signing_secret is defined %}
-        - name: {{ ansible_operator_meta.name }}-signing-scripts
+        - name: {{ signing_scripts_configmap }}
           configMap:
             name: {{ signing_scripts_configmap }}
             defaultMode: 0755
@@ -100,7 +100,7 @@ spec:
                 key: collection_sign.sh
               - path: container_sign.sh
                 key: container_sign.sh
-        - name: {{ ansible_operator_meta.name }}-signing-galaxy
+        - name: {{ signing_secret }}
           secret:
             secretName: {{ signing_secret }}
             items:
@@ -232,15 +232,15 @@ spec:
               readOnly: true
 {% endif %}
 {% if signing_secret is defined %}
-            - name: {{ ansible_operator_meta.name }}-signing-scripts
+            - name: {{ signing_scripts_configmap }}
               mountPath: /var/lib/pulp/scripts/collection_sign.sh
               subPath: collection_sign.sh
               readOnly: true
-            - name: {{ ansible_operator_meta.name }}-signing-scripts
+            - name: {{ signing_scripts_configmap }}
               mountPath: /var/lib/pulp/scripts/container_sign.sh
               subPath: container_sign.sh
               readOnly: true
-            - name: {{ ansible_operator_meta.name }}-signing-galaxy
+            - name: {{ signing_secret }}
               mountPath: /etc/pulp/keys/signing_service.gpg
               subPath: signing_service.gpg
               readOnly: true
@@ -344,15 +344,15 @@ spec:
             - name: gpg-file-storage
               mountPath: "/var/lib/pulp/.gnupg"
 {% endif %}
-            - name: {{ ansible_operator_meta.name }}-signing-scripts
+            - name: {{ signing_scripts_configmap }}
               mountPath: /var/lib/pulp/scripts/collection_sign.sh
               subPath: collection_sign.sh
               readOnly: true
-            - name: {{ ansible_operator_meta.name }}-signing-scripts
+            - name: {{ signing_scripts_configmap }}
               mountPath: /var/lib/pulp/scripts/container_sign.sh
               subPath: container_sign.sh
               readOnly: true
-            - name: {{ ansible_operator_meta.name }}-signing-galaxy
+            - name: {{ signing_secret }}
               mountPath: "/etc/pulp/keys/signing_service.gpg"
               subPath: signing_service.gpg
               readOnly: true

--- a/roles/galaxy-content/templates/galaxy-content.deployment.yaml.j2
+++ b/roles/galaxy-content/templates/galaxy-content.deployment.yaml.j2
@@ -88,11 +88,11 @@ spec:
               - path: database_fields.symmetric.key
                 key: database_fields.symmetric.key
 {% if signing_secret is defined %}
-        - name: {{ ansible_operator_meta.name }}-signing-scripts
+        - name: {{ signing_scripts_configmap }}
           configMap:
             name: {{ signing_scripts_configmap }}
             defaultMode: 0755
-        - name: {{ ansible_operator_meta.name }}-signing-galaxy
+        - name: {{ signing_secret }}
           secret:
             secretName: {{ signing_secret }}
             items:
@@ -232,15 +232,15 @@ spec:
               subPath: database_fields.symmetric.key
               readOnly: true
 {% if signing_secret is defined %}
-            - name: {{ ansible_operator_meta.name }}-signing-scripts
+            - name: {{ signing_scripts_configmap }}
               mountPath: "/var/lib/pulp/scripts/collection_sign.sh"
               subPath: collection_sign.sh
               readOnly: true
-            - name: {{ ansible_operator_meta.name }}-signing-scripts
+            - name: {{ signing_scripts_configmap }}
               mountPath: "/var/lib/pulp/scripts/container_sign.sh"
               subPath: container_sign.sh
               readOnly: true
-            - name: {{ ansible_operator_meta.name }}-signing-galaxy
+            - name: {{ signing_secret }}
               mountPath: "/etc/pulp/keys/signing_service.gpg"
               subPath: signing_service.gpg
               readOnly: true

--- a/roles/galaxy-worker/templates/galaxy-worker.deployment.yaml.j2
+++ b/roles/galaxy-worker/templates/galaxy-worker.deployment.yaml.j2
@@ -80,11 +80,11 @@ spec:
         - name: gpg-file-storage
           emptyDir: {}
 {% endif %}
-        - name: {{ ansible_operator_meta.name }}-signing-scripts
+        - name: {{ signing_scripts_configmap }}
           configMap:
             name: {{ signing_scripts_configmap }}
             defaultMode: 0755
-        - name: {{ ansible_operator_meta.name }}-signing-galaxy
+        - name: {{ signing_secret }}
           secret:
             secretName: {{ signing_secret }}
             items:
@@ -158,15 +158,15 @@ spec:
               subPath: database_fields.symmetric.key
               readOnly: true
 {% if signing_secret is defined %}
-            - name: {{ ansible_operator_meta.name }}-signing-scripts
+            - name: {{ signing_scripts_configmap }}
               mountPath: "/var/lib/pulp/scripts/collection_sign.sh"
               subPath: collection_sign.sh
               readOnly: true
-            - name: {{ ansible_operator_meta.name }}-signing-scripts
+            - name: {{ signing_scripts_configmap }}
               mountPath: "/var/lib/pulp/scripts/container_sign.sh"
               subPath: container_sign.sh
               readOnly: true
-            - name: {{ ansible_operator_meta.name }}-signing-galaxy
+            - name: {{ signing_secret }}
               mountPath: "/etc/pulp/keys/signing_service.gpg"
               subPath: signing_service.gpg
               readOnly: true
@@ -255,7 +255,7 @@ spec:
             - name: gpg-file-storage
               mountPath: "/var/lib/pulp/.gnupg"
 {% endif %}
-            - name: {{ ansible_operator_meta.name }}-signing-galaxy
+            - name: {{ signing_secret }}
               mountPath: "/etc/pulp/keys/signing_service.gpg"
               subPath: signing_service.gpg
               readOnly: true


### PR DESCRIPTION
##### SUMMARY

The signing secret and signing configmap's names were incorrectly hardcoded and would not use a user-provided resource unless the naming was the hardcoded value.

This PR fixes the resources to be named according to what the user provides for secret and configmap values.