### PR TITLE
Create galaxy_v1beta1_galaxy_cr.unauthenticated-demo.yaml

### DIFF
--- a/config/samples/galaxy_v1beta1_galaxy_cr.unauthenticated-demo.yaml
+++ b/config/samples/galaxy_v1beta1_galaxy_cr.unauthenticated-demo.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: galaxy.ansible.com/v1beta1
+kind: Galaxy
+metadata:
+  name: galaxy
+  namespace: galaxy
+spec:
+  hostname: galaxy.local
+  ingress_type: ingress
+  storage_type: File
+  file_storage_access_mode: ReadWriteOnce
+  file_storage_size: 8Gi
+  no_log: false
+  image_pull_policy: IfNotPresent
+  pulp_settings:
+    GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS: true
+    GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD: true


### PR DESCRIPTION


##### SUMMARY
Had a hard time reconciling how to get this working but it seems to work now, so I figure I'd share this deployment in case other people want to allow their galaxy server's collections to be reachable without auth.

##### ADDITIONAL INFORMATION
I'm trying to be helpful in life.
