### PR TITLE
postgres: Wait for stateful on managed db

### DIFF
--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -152,6 +152,7 @@
   until: _pg_sts_status['resources'][0]['status']['availableReplicas'] == _pg_sts_status['resources'][0]['status']['replicas']
   retries: 20
   delay: 10
+  when: managed_database | bool
 
 - operator_sdk.util.k8s_status:
     api_version: "{{ api_version }}"


### PR DESCRIPTION
##### SUMMARY

When using an external database then the `Check PostgreSQL status` task is waiting and failing because there's no such stateful resource
This was introduced in 2641fcd

##### ADDITIONAL INFORMATION

```console
TASK [Check PostgreSQL status] ********************************
fatal: [localhost]: FAILED! => {"msg": "The conditional check '_pg_sts_status['resources'][0]['status']['availableReplicas'] == _pg_sts_status['resources'][0]['status']['replicas']' failed. The error was: error while evaluating conditional (_pg_sts_status['resources'][0]['status']['availableReplicas'] == _pg_sts_status['resources'][0]['status']['replicas']): list object has no element 0"}
```
