### PR TITLE
ci: Add scenario for external database

### DIFF
--- a/.ci/assets/kubernetes/galaxy-external-database.secret.yaml
+++ b/.ci/assets/kubernetes/galaxy-external-database.secret.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: 'example-galaxy-external-database'
+stringData:
+  host: 'galaxy-postgresql'
+  port: '5555'
+  database: 'galaxy'
+  username: 'galaxy'
+  password: 'galaxy'
+  sslmode: 'prefer'
+  type: 'unmanaged'
+type: Opaque

--- a/.ci/scripts/backup_and_restore.sh
+++ b/.ci/scripts/backup_and_restore.sh
@@ -18,7 +18,11 @@ RESTORE_RESOURCE=galaxy_v1beta1_galaxyrestore_cr.ci.yaml
 if [[ "$CI_TEST" == "true" ]]; then
   CUSTOM_RESOURCE=galaxy_v1beta1_galaxy_cr.ci.yaml
 elif [[ "$CI_TEST" == "galaxy" && "$CI_TEST_STORAGE" == "filesystem" ]]; then
-  CUSTOM_RESOURCE=galaxy_v1beta1_galaxy_cr.galaxy.ci.yaml
+  if [[ "$CI_TEST_DATABASE" == "external" ]]; then
+    CUSTOM_RESOURCE=galaxy_v1beta1_galaxy_cr.galaxy.externaldb.ci.yaml
+  else
+    CUSTOM_RESOURCE=galaxy_v1beta1_galaxy_cr.galaxy.ci.yaml
+  fi
 elif [[ "$CI_TEST" == "galaxy" && "$CI_TEST_STORAGE" == "azure" ]]; then
   CUSTOM_RESOURCE=galaxy_v1beta1_galaxy_cr.galaxy.azure.ci.yaml
 elif [[ "$CI_TEST" == "galaxy" && "$CI_TEST_STORAGE" == "s3" ]]; then

--- a/.ci/scripts/prepare-external-database.sh
+++ b/.ci/scripts/prepare-external-database.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+#!/usr/bin/env bash
+
+if [[ "$CI_TEST_DATABASE" == "external" ]]; then
+  docker volume create postgresql
+  docker run -d -p 5555:5432 --name postgresql -e POSTGRESQL_USER=galaxy -e POSTGRESQL_PASSWORD=galaxy -e POSTGRESQL_DATABASE=galaxy -v postgresql:/var/lib/pgsql/data quay.io/sclorg/postgresql-15-c9s:latest
+  echo $(minikube ip)   galaxy-postgresql | sudo tee -a /etc/hosts
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,19 @@ jobs:
         include:
           - STORAGE: filesystem
             IMAGE: minimal
+            DATABASE: internal
+          - STORAGE: filesystem
+            IMAGE: minimal
+            DATABASE: external
           - STORAGE: filesystem
             IMAGE: s6
+            DATABASE: internal
           - STORAGE: azure
             IMAGE: minimal
+            DATABASE: internal
           - STORAGE: s3
             IMAGE: minimal
+            DATABASE: internal
     steps:
       - uses: actions/checkout@v2
         with:
@@ -50,6 +57,7 @@ jobs:
           echo "CI_TEST=true" >> $GITHUB_ENV
           echo "CI_TEST_STORAGE=${{ matrix.STORAGE }}" >> $GITHUB_ENV
           echo "CI_TEST_IMAGE=${{ matrix.IMAGE }}" >> $GITHUB_ENV
+          echo "CI_TEST_DATABASE=${{ matrix.DATABASE }}" >> $GITHUB_ENV
           echo "API_ROOT=/api/galaxy/pulp/" >> $GITHUB_ENV
         shell: bash
       - name: Start minikube
@@ -79,8 +87,9 @@ jobs:
           sudo -E docker images
         shell: bash
 
-      - name: Prepare Object Storage
+      - name: Prepare External Database and Object Storage
         run: |
+          .ci/scripts/prepare-external-database.sh
           .ci/scripts/prepare-object-storage.sh
         shell: bash
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,12 +14,19 @@ jobs:
         include:
           - STORAGE: filesystem
             IMAGE: minimal
+            DATABASE: internal
+          - STORAGE: filesystem
+            IMAGE: minimal
+            DATABASE: external
           - STORAGE: filesystem
             IMAGE: s6
+            DATABASE: internal
           - STORAGE: azure
             IMAGE: minimal
+            DATABASE: internal
           - STORAGE: s3
             IMAGE: minimal
+            DATABASE: internal
     steps:
       - name: PR head repo
         id: head_repo_name
@@ -53,6 +60,7 @@ jobs:
           echo "CI_TEST=true" >> $GITHUB_ENV
           echo "CI_TEST_STORAGE=${{ matrix.STORAGE }}" >> $GITHUB_ENV
           echo "CI_TEST_IMAGE=${{ matrix.IMAGE }}" >> $GITHUB_ENV
+          echo "CI_TEST_DATABASE=${{ matrix.DATABASE }}" >> $GITHUB_ENV
           echo "API_ROOT=/api/galaxy/pulp/" >> $GITHUB_ENV
         shell: bash
 
@@ -83,8 +91,9 @@ jobs:
           sudo -E docker images
         shell: bash
 
-      - name: Prepare Object Storage
+      - name: Prepare External Database and Object Storage
         run: |
+          .ci/scripts/prepare-external-database.sh
           .ci/scripts/prepare-object-storage.sh
         shell: bash
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -2,9 +2,11 @@
   description = "Our test install exports a test only PRIVATE KEY"
   paths = [
     ".ci/assets/kubernetes/galaxy-container-auth.secret.yaml",
+    ".ci/assets/kubernetes/galaxy-external-database.secret.yaml",
     ".ci/assets/kubernetes/galaxy-object-storage.aws.secret.yaml",
     ".ci/assets/kubernetes/galaxy-object-storage.azure.secret.yaml",
     ".ci/assets/kubernetes/galaxy_sign.secret.yaml",
+    ".ci/scripts/prepare-external-database.sh",
     ".ci/scripts/prepare-object-storage.sh",
     "config/samples/galaxyproject_v1beta1_galaxy_cr.default.yaml",
     "containers/compose/certs/database_fields.symmetric.key",

--- a/config/samples/galaxy_v1beta1_galaxy_cr.galaxy.externaldb.ci.yaml
+++ b/config/samples/galaxy_v1beta1_galaxy_cr.galaxy.externaldb.ci.yaml
@@ -1,0 +1,53 @@
+apiVersion: galaxy.ansible.com/v1beta1
+kind: Galaxy
+metadata:
+  name: example-galaxy
+spec:
+  image: quay.io/ansible/galaxy-ng
+  image_version: latest
+  image_web: quay.io/ansible/galaxy-ui
+  image_web_version: latest
+  no_log: false
+  admin_password_secret: "example-galaxy-admin-password"
+  postgres_configuration_secret: "example-galaxy-external-database"
+  signing_secret: "signing-galaxy"
+  signing_scripts_configmap: "signing-scripts"
+  storage_type: File
+  ingress_type: nodeport
+  # k3s local-path requires this
+  file_storage_access_mode: "ReadWriteMany"
+  # We have a little over 10GB free on GHA VMs/instances
+  file_storage_size: "10Gi"
+  pulp_settings:
+    allowed_export_paths:
+      - /tmp
+    allowed_import_paths:
+      - /tmp
+    telemetry: false
+  content:
+    replicas: 1
+    resource_requirements:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+      limits:
+        cpu: 800m
+        memory: 1Gi
+  worker:
+    replicas: 1
+    resource_requirements:
+      requests:
+        cpu: 150m
+        memory: 256Mi
+      limits:
+        cpu: 800m
+        memory: 1Gi
+  web:
+    replicas: 1
+    resource_requirements:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 800m
+        memory: 1Gi

--- a/roles/restore/tasks/deploy_galaxy.yml
+++ b/roles/restore/tasks/deploy_galaxy.yml
@@ -14,7 +14,7 @@
 
 - name: Set custom resource spec variable from backup
   set_fact:
-    cr_spec_from_backup: "{{ cr_object.stdout }}"
+    cr_spec_from_backup: "{{ cr_object.stdout | from_yaml }}"
     cr_spec_strip: "{ "
     admin_str: "admin_password_secret: {{ admin_password_name }}"
     storage_str: "object_storage_{{ storage_type | lower }}_secret: {{ storage_secret }}"
@@ -26,7 +26,7 @@
 
 - name: Remove postgres_configuration_secret from spec
   set_fact:
-    cr_spec_from_backup: "{{ (cr_spec_from_backup[:-2] | from_yaml) | combine({'postgres_configuration_secret': db_secret_name}, recursive=True) }}"
+    cr_spec_from_backup: "{{ cr_spec_from_backup | combine({'postgres_configuration_secret': db_secret_name}, recursive=True) }}"
   when:
     - database_type is defined
     - database_type == 'managed'

--- a/up.sh
+++ b/up.sh
@@ -74,8 +74,17 @@ elif [[ "$CI_TEST" == "galaxy" && "$CI_TEST_IMAGE" == "s6" ]]; then
   echo "Will deploy signing secret for testing ..."
   $KUBECTL apply -f $KUBE_ASSETS_DIR/galaxy_sign.secret.yaml
   $KUBECTL apply -f $KUBE_ASSETS_DIR/signing_scripts.configmap.yaml
-elif [[ "$CI_TEST" == "galaxy" ]]; then
+elif [[ "$CI_TEST" == "galaxy" && "$CI_TEST_DATABASE" == "internal" ]]; then
   CUSTOM_RESOURCE=galaxy_v1beta1_galaxy_cr.galaxy.ci.yaml
+  echo "Will deploy admin password secret for testing ..."
+  $KUBECTL apply -f $KUBE_ASSETS_DIR/galaxy-admin-password.secret.yaml
+  echo "Will deploy signing secret for testing ..."
+  $KUBECTL apply -f $KUBE_ASSETS_DIR/galaxy_sign.secret.yaml
+  $KUBECTL apply -f $KUBE_ASSETS_DIR/signing_scripts.configmap.yaml
+elif [[ "$CI_TEST" == "galaxy" && "$CI_TEST_DATABASE" == "external" ]]; then
+  CUSTOM_RESOURCE=galaxy_v1beta1_galaxy_cr.galaxy.externaldb.ci.yaml
+  echo "Will deploy postgresql secret for testing..."
+  $KUBECTL apply -f $KUBE_ASSETS_DIR/galaxy-external-database.secret.yaml
   echo "Will deploy admin password secret for testing ..."
   $KUBECTL apply -f $KUBE_ASSETS_DIR/galaxy-admin-password.secret.yaml
   echo "Will deploy signing secret for testing ..."


### PR DESCRIPTION
##### SUMMARY

This adds a new CI scenario for deploying the galaxy operator with an external database.

##### ADDITIONAL INFORMATION

The external database is just a postgresql container running on the host via docker (like azurite and minio).
The postgresql secret is created and referenced in the externaldb CI CRD.
The postgresql container is mapped on port 5555 on the host to avoid conflicting with existing postgresql instance running by default.
