### PR TITLE
fix: correct remote scheme to https when  any tls secret is specified

### DIFF
--- a/roles/galaxy-config/tasks/get_node_ip.yml
+++ b/roles/galaxy-config/tasks/get_node_ip.yml
@@ -14,9 +14,7 @@
 - name: Set web protocol
   set_fact:
     web_protocol: "https"
-  when: >-
-    ingress_tls_secret | length
-    or route_tls_secret | length
+  when: ingress_tls_secret | length
 
 - name: Set node address for ingress
   set_fact:

--- a/roles/galaxy-config/tasks/get_node_ip.yml
+++ b/roles/galaxy-config/tasks/get_node_ip.yml
@@ -14,9 +14,9 @@
 - name: Set web protocol
   set_fact:
     web_protocol: "https"
-  when:
-    - ingress_tls_secret | length
-    - route_tls_secret | length
+  when: >-
+    ingress_tls_secret | length
+    or route_tls_secret | length
 
 - name: Set node address for ingress
   set_fact:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

fixes #122 

This PR corrects `when` statement to be `true` if `ingress_tls_secret` OR `route_tls_secret` is specified.

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

Tested CR that includes following snippet:

```yaml
apiVersion: galaxy.ansible.com/v1beta1
kind: Galaxy
metadata:
  name: galaxy
spec:

  image: quay.io/ansible/galaxy-ng
  image_version: b7b07e96
  image_web: quay.io/ansible/galaxy-ui
  image_web_version: 19fd5a2b

  ingress_type: ingress
  ingress_tls_secret: galaxy-secret-tls
  hostname: galaxy.example.com

  pulp_settings:
    galaxy_collection_signing_service: ""
    galaxy_container_signing_service: ""
    token_auth_disabled: "True"
    galaxy_enable_unauthenticated_collection_access: "True"
    galaxy_enable_unauthenticated_collection_download: "True"

  ...
```

```bash
# Ensure settings.py contains URLs with HTTPS
$ kubectl -n galaxy exec deployment/galaxy-api -- cat /etc/pulp/settings.py | grep http
CONTENT_ORIGIN = "https://galaxy.example.com"
ANSIBLE_API_HOSTNAME = "https://galaxy.example.com"
TOKEN_SERVER = "https://galaxy.example.com/token/"
CSRF_TRUSTED_ORIGINS = ["http://galaxy.example.com", "https://galaxy.example.com"]
```

```bash
# Ensure the API returns the URL for tar.gz file with HTTPS scheme
$ curl -sk https://galaxy.example.com/api/galaxy/content/community/v3/plugin/ansible/content/community/collections/index/community/general/versions/8.6.0/ | jq -r '.download_url'
https://galaxy.example.com/api/galaxy/v3/plugin/ansible/content/community/collections/artifacts/community-general-8.6.0.tar.gz
```

```bash
# Ensure ansible-galaxy command downloads via HTTPS:
$ cat ansible.cfg 
...
[galaxy]
server_list = published_repo, community_repo

[galaxy_server.published_repo]
url=https://galaxy.example.com/api/galaxy/
token=...

[galaxy_server.community_repo]
url=https://galaxy.example.com/api/galaxy/content/community/
token=...

$ rm -rf ~/.ansible/galaxy_cache/
$ ansible-galaxy collection install --force community.general -c
Starting galaxy collection install process
Process install dependency map
Starting collection install process
Downloading https://galaxy.example.com/api/galaxy/v3/plugin/ansible/content/community/collections/artifacts/community-general-8.6.0.tar.gz to /home/kuro/.ansible/tmp/ansible-local-1411892hjdn7io9/tmp2022k9y9/community-general-8.6.0-5hzr9lxj
Installing 'community.general:8.6.0' to '/home/kuro/.ansible/collections/ansible_collections/community/general'
community.general:8.6.0 was installed successfully
```

```bash
# Ensure redirection works as expected
## Accessing over HTTP returns 301
$ curl -v http://galaxy.example.com/api/galaxy/v3/plugin/ansible/content/community/collections/artifacts/community-general-8.6.0.tar.gz
...
< HTTP/1.1 301 Moved Permanently
< Content-Type: text/html; charset=utf-8
< Location: https://galaxy.example.com/api/galaxy/v3/plugin/ansible/content/community/collections/artifacts/community-general-8.6.0.tar.gz
...
< 
<a href="https://galaxy.example.com/api/galaxy/v3/plugin/ansible/content/community/collections/artifacts/community-general-8.6.0.tar.gz">Moved Permanently</a>.
...

## Specify HTTP instead of HTTPS in ansible.cfg
$ cat ansible.cfg 
...
[galaxy]
server_list = published_repo, community_repo

[galaxy_server.published_repo]
url=http://galaxy.example.com/api/galaxy/
token=...

[galaxy_server.community_repo]
url=http://galaxy.example.com/api/galaxy/content/community/
token=...

## ansible-galaxy works as expected
$ rm -rf ~/.ansible/galaxy_cache/
$ ansible-galaxy collection install --force community.general -c
Starting galaxy collection install process
Process install dependency map
Starting collection install process
Downloading https://galaxy.example.com/api/galaxy/v3/plugin/ansible/content/community/collections/artifacts/community-general-8.6.0.tar.gz to /home/kuro/.ansible/tmp/ansible-local-1416551qcifzuxq/tmpjs5n7vhy/community-general-8.6.0-72m9sdnw
Installing 'community.general:8.6.0' to '/home/kuro/.ansible/collections/ansible_collections/community/general'
community.general:8.6.0 was installed successfully
```

Also tested:

- Synching collections from galaxy.ansible.com works
- Publishing custom collection works
- Pushing / pulling container image works
- CR with `ingress_type: ingress` without TLS secret works (everything is done over HTTP)