### PR TITLE
Add support for spec overrides when restoring Galaxy

### DIFF
--- a/config/crd/bases/galaxy_v1beta1_galaxyrestore_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxyrestore_crd.yaml
@@ -78,6 +78,10 @@ spec:
                 postgres_label_selector:
                   description: Label selector used to identify postgres pod for executing migration
                   type: string
+                spec_overrides:
+                  description: Overrides for the Galaxy spec
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 no_log:
                   default: true
                   description: Configure no_log (hides sensitive information in operator/task logs)

--- a/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
@@ -136,11 +136,6 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
         - urn:alm:descriptor:io.kubernetes:Secret
-      - displayName: Database migration label selector
-        path: postgres_label_selector
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Postgres Keep Old Data PVC After Upgrade
         path: postgres_keep_pvc_after_upgrade
         x-descriptors:
@@ -151,6 +146,10 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Galaxy Spec Overrides
+        path: spec_overrides
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
       - displayName: Node Selector
         path: node_selector
         x-descriptors:

--- a/roles/restore/defaults/main.yml
+++ b/roles/restore/defaults/main.yml
@@ -28,3 +28,5 @@ restore_resource_requirements:
   requests:
     cpu: "25m"
     memory: "32Mi"
+
+spec_overrides: {}

--- a/roles/restore/tasks/deploy_galaxy.yml
+++ b/roles/restore/tasks/deploy_galaxy.yml
@@ -36,6 +36,11 @@
   set_fact:
     cr_spec: "{{ cr_spec_from_backup }}"
 
+- name: Combine spec_overrides with spec
+  set_fact:
+    cr_spec: "{{ cr_spec | default({}) | combine(spec_overrides) }}"
+  no_log: "{{ no_log }}"
+
 - name: Deploy object
   k8s:
     state: present


### PR DESCRIPTION
Port of restore overrides PR from the awx-operator:
* https://github.com/ansible/awx-operator/pull/1862

##### SUMMARY

There are often times where you might want to override specific parameters on the Galaxy spec when restoring from a backup. One such case is when you want to extend the database PVC size.  

To extend the storage size of your postgres PVC, with this change, you can now:
1. Create an GalaxyBackup
2. Create an GalaxyRestore with a spec_overrides entry for `spec_overrides.postgres_storage_requirements.requests: 110Gi` on your GalaxyRestore object
3. The new deployment will have any spec_overrides preferentially included on the new Galaxy CR spec.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature
