### PR TITLE
feat: implement extra_settings_files

### DIFF
--- a/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
@@ -73,6 +73,28 @@ spec:
                         type: boolean
                     type: object
                 type: object
+              extra_settings_files:
+                description: Extra ConfigMaps or Secrets of settings files to specify for AWX
+                properties:
+                  configmaps:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        key:
+                          type: string
+                      type: object
+                    type: array
+                  secrets:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        key:
+                          type: string
+                      type: object
+                    type: array
+                type: object
               bundle_cacert_secret:
                 description: Secret where the trusted Certificate Authority Bundle is stored
                 type: string

--- a/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
@@ -333,6 +333,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Extra Settings Files
+        path: extra_settings_files
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Redis deployment configuration
         path: redis
         x-descriptors:

--- a/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
+++ b/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
@@ -68,6 +68,7 @@ spec:
             items:
               - path: settings.py
                 key: settings.py
+        {{ lookup("template", "../galaxy-config/templates/common/volumes/extra_settings_files.yaml.j2")  | indent(width=8) | trim }}
         - name: {{ ansible_operator_meta.name }}-db-fields-encryption
           secret:
             secretName: {{ db_fields_encryption_secret }}
@@ -203,6 +204,7 @@ spec:
               mountPath: "/etc/pulp/settings.py"
               subPath: settings.py
               readOnly: true
+            {{ lookup("template", "../galaxy-config/templates/common/volume_mounts/extra_settings_files.yaml.j2")  | indent(width=12) | trim }}
             - name: {{ ansible_operator_meta.name }}-db-fields-encryption
               mountPath: "/etc/pulp/keys/database_fields.symmetric.key"
               subPath: database_fields.symmetric.key
@@ -283,6 +285,7 @@ spec:
               mountPath: "/etc/pulp/settings.py"
               subPath: settings.py
               readOnly: true
+            {{ lookup("template", "../galaxy-config/templates/common/volume_mounts/extra_settings_files.yaml.j2")  | indent(width=12) | trim }}
             - name: {{ ansible_operator_meta.name }}-db-fields-encryption
               mountPath: "/etc/pulp/keys/database_fields.symmetric.key"
               subPath: database_fields.symmetric.key
@@ -332,6 +335,7 @@ spec:
               mountPath: "/etc/pulp/settings.py"
               subPath: settings.py
               readOnly: true
+            {{ lookup("template", "../galaxy-config/templates/common/volume_mounts/extra_settings_files.yaml.j2")  | indent(width=12) | trim }}
             - name: {{ ansible_operator_meta.name }}-db-fields-encryption
               mountPath: "/etc/pulp/keys/database_fields.symmetric.key"
               subPath: database_fields.symmetric.key

--- a/roles/galaxy-config/defaults/main.yml
+++ b/roles/galaxy-config/defaults/main.yml
@@ -1,1 +1,2 @@
 ---
+extra_settings_files: {}

--- a/roles/galaxy-config/templates/common/volume_mounts/extra_settings_files.yaml.j2
+++ b/roles/galaxy-config/templates/common/volume_mounts/extra_settings_files.yaml.j2
@@ -1,0 +1,16 @@
+{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
+{% for configmap in extra_settings_files.configmaps %}
+- name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
+  mountPath: "/etc/pulp/conf.d/{{ configmap.key }}"
+  subPath: {{ configmap.key }}
+  readOnly: true
+{% endfor %}
+{% endif %}
+{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
+{% for secret in extra_settings_files.secrets %}
+- name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
+  mountPath: "/etc/pulp/conf.d/{{ secret.key }}"
+  subPath: {{ secret.key }}
+  readOnly: true
+{% endfor %}
+{% endif %}

--- a/roles/galaxy-config/templates/common/volumes/extra_settings_files.yaml.j2
+++ b/roles/galaxy-config/templates/common/volumes/extra_settings_files.yaml.j2
@@ -1,0 +1,20 @@
+{% if extra_settings_files.configmaps is defined and extra_settings_files.configmaps | length %}
+{% for configmap in extra_settings_files.configmaps %}
+- name: {{ ansible_operator_meta.name }}-{{ configmap.key | replace('_', '-') | replace('.', '-') | lower }}-configmap
+  configMap:
+    name: {{ configmap.name }}
+    items:
+      - key: {{ configmap.key }}
+        path: {{ configmap.key }}
+{% endfor %}
+{% endif %}
+{% if extra_settings_files.secrets is defined and extra_settings_files.secrets | length %}
+{% for secret in extra_settings_files.secrets %}
+- name: {{ ansible_operator_meta.name }}-{{ secret.key | replace('_', '-') | replace('.', '-') | lower }}-secret
+  secret:
+    secretName: {{ secret.name }}
+    items:
+      - key: {{ secret.key }}
+        path: {{ secret.key }}
+{% endfor %}
+{% endif %}

--- a/roles/galaxy-config/templates/galaxy-server.secret.yaml.j2
+++ b/roles/galaxy-config/templates/galaxy-server.secret.yaml.j2
@@ -6,6 +6,20 @@ metadata:
   namespace: "{{ ansible_operator_meta.namespace }}"
 stringData:
   settings.py: |
-    {% for setting, value in pulp_combined_settings.items() %}
+    import os
+    import traceback
+
+    from split_settings.tools import optional, include
+
+{% for setting, value in pulp_combined_settings.items() %}
     {{ setting | upper }} = {{ value | string | capitalize if value | string in ["True", "False"] else value | to_json }}
-    {% endfor %}
+{% endfor %}
+
+    # Attempt to load settings from /etc/pulp/conf.d/*.py.
+    settings_dir = os.environ.get('PULP_SETTINGS_DIR', '/etc/pulp/conf.d/')
+    settings_files = os.path.join(settings_dir, '*.py')
+    try:
+        include(optional(settings_files), scope=locals())
+    except ImportError:
+        traceback.print_exc()
+        sys.exit(1)

--- a/roles/galaxy-content/templates/galaxy-content.deployment.yaml.j2
+++ b/roles/galaxy-content/templates/galaxy-content.deployment.yaml.j2
@@ -81,6 +81,7 @@ spec:
             items:
               - path: settings.py
                 key: settings.py
+        {{ lookup("template", "../galaxy-config/templates/common/volumes/extra_settings_files.yaml.j2")  | indent(width=8) | trim }}
         - name: {{ ansible_operator_meta.name }}-db-fields-encryption
           secret:
             secretName: {{ db_fields_encryption_secret }}
@@ -148,6 +149,7 @@ spec:
               mountPath: "/etc/pulp/settings.py"
               subPath: settings.py
               readOnly: true
+            {{ lookup("template", "../galaxy-config/templates/common/volume_mounts/extra_settings_files.yaml.j2")  | indent(width=12) | trim }}
             - name: {{ ansible_operator_meta.name }}-db-fields-encryption
               mountPath: "/etc/pulp/keys/database_fields.symmetric.key"
               subPath: database_fields.symmetric.key
@@ -227,6 +229,7 @@ spec:
               mountPath: "/etc/pulp/settings.py"
               subPath: settings.py
               readOnly: true
+            {{ lookup("template", "../galaxy-config/templates/common/volume_mounts/extra_settings_files.yaml.j2")  | indent(width=12) | trim }}
             - name: {{ ansible_operator_meta.name }}-db-fields-encryption
               mountPath: "/etc/pulp/keys/database_fields.symmetric.key"
               subPath: database_fields.symmetric.key

--- a/roles/galaxy-worker/templates/galaxy-worker.deployment.yaml.j2
+++ b/roles/galaxy-worker/templates/galaxy-worker.deployment.yaml.j2
@@ -69,6 +69,7 @@ spec:
             items:
               - path: settings.py
                 key: settings.py
+        {{ lookup("template", "../galaxy-config/templates/common/volumes/extra_settings_files.yaml.j2")  | indent(width=8) | trim }}
         - name: {{ ansible_operator_meta.name }}-db-fields-encryption
           secret:
             secretName: {{ db_fields_encryption_secret }}
@@ -153,6 +154,7 @@ spec:
               mountPath: "/etc/pulp/settings.py"
               subPath: settings.py
               readOnly: true
+            {{ lookup("template", "../galaxy-config/templates/common/volume_mounts/extra_settings_files.yaml.j2")  | indent(width=12) | trim }}
             - name: {{ ansible_operator_meta.name }}-db-fields-encryption
               mountPath: "/etc/pulp/keys/database_fields.symmetric.key"
               subPath: database_fields.symmetric.key
@@ -220,6 +222,7 @@ spec:
               mountPath: "/etc/pulp/settings.py"
               subPath: settings.py
               readOnly: true
+            {{ lookup("template", "../galaxy-config/templates/common/volume_mounts/extra_settings_files.yaml.j2")  | indent(width=12) | trim }}
             - name: {{ ansible_operator_meta.name }}-db-fields-encryption
               mountPath: "/etc/pulp/keys/database_fields.symmetric.key"
               subPath: database_fields.symmetric.key


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This PR implements `extra_settings_files`, which is almost the same as my PR for AWX Operator https://github.com/ansible/awx-operator/pull/1836

Required module (`split_settings`) to load additional `*.py` files is already installed in galaxy images: https://github.com/ansible/galaxy_ng/blob/c52e9b4e5548ca38946d7cc1bd8624459def1ec1/requirements/requirements.common.txt#L127-L128

**Design:**

- Users can add extra settings by mounting `*.py` files from ConfigMaps or Secrets
- This feature mounts specified `*.py` files under `/etc/pulp/conf.d` in following pods which already have `settngs.py`
  - galaxy-api
  - galaxy-content
  - galaxy-worker
- Users can specify multiple ConfigMaps and Secrets
- Users can include multiple files in a single ConfigMap or Secret

**Restrictions:**

Completely the same as described in https://github.com/ansible/awx-operator/pull/1836

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ADDITIONAL INFORMATION

Tested with and without `extra_settings_files`:

**Without `extra_settings_files`**

```yaml
---
apiVersion: galaxy.ansible.com/v1beta1
kind: Galaxy
metadata:
  namespace: galaxy
  name: galaxy
spec:
  ingress_type: nodeport
  nodeport_port: "30180"
  storage_type: File
  file_storage_access_mode: ReadWriteOnce
  file_storage_size: 8Gi
  no_log: false

  image: quay.io/ansible/galaxy-ng
  image_version: 9d2f8ce1
  image_web: quay.io/ansible/galaxy-ui
  image_web_version: 6116e760
```

Ensure there is no `/etc/pulp/conf.d`

```bash
$ kubectl -n galaxy exec -it deployment/galaxy-api -- ls -l /etc/pulp
total 4
drwxrwxr-x. 2 galaxy root    6 May  1 13:01 certs
drwxrwxr-x. 1 galaxy root  118 May 24 12:53 keys
-rw-r--r--. 1 root   root 1531 May 24 12:52 settings.py
```

Even if there is no actual directory and files, `include()` does not cause error since `optional()` is used to load files.

```
$ kubectl -n galaxy exec -it deployment/galaxy-api -- cat /etc/pulp/settings.py
import os
import traceback

from split_settings.tools import optional, include

GALAXY_API_PATH_PREFIX = "api/galaxy"
...
CSRF_TRUSTED_ORIGINS = ["http://192.168.0.221:30180", "https://192.168.0.221:30180"]

# Attempt to load settings from /etc/pulp/conf.d/*.py.
settings_dir = os.environ.get('PULP_SETTINGS_DIR', '/etc/pulp/conf.d/')
settings_files = os.path.join(settings_dir, '*.py')
try:
    include(optional(settings_files), scope=locals())
except ImportError:
    traceback.print_exc()
    sys.exit(1)
```

**With `extra_settings_files`**

```yaml
---
apiVersion: galaxy.ansible.com/v1beta1
kind: Galaxy
metadata:
  namespace: galaxy
  name: galaxy
spec:
  ingress_type: nodeport
  nodeport_port: "30180"
  storage_type: File
  file_storage_access_mode: ReadWriteOnce
  file_storage_size: 8Gi
  no_log: false

  image: quay.io/ansible/galaxy-ng
  image_version: 9d2f8ce1
  image_web: quay.io/ansible/galaxy-ui
  image_web_version: 6116e760

  extra_settings_files:
    configmaps:
      - name: demo-configmap-01
        key: democonfigmap01_01.py
    secrets:
      - name: demo-secret-01
        key: demosecret01_01.py
      - name: demo-secret-01
        key: demosecret01_02.py
      - name: demo-secret-02
        key: demosecret02_01.py
```

```yaml
---
apiVersion: v1
kind: ConfigMap
metadata:
  namespace: galaxy
  name: demo-configmap-01
data:
  democonfigmap01_01.py: |
    GALAXY_FEATURE_FLAGS = {
      "display_repositories": True,
      # True by default so set False for testing
      "execution_environments": False,
      "legacy_roles": False,
      "ai_deny_index": False,
      "dab_resource_registry": False,
    }
---
apiVersion: v1
kind: Secret
metadata:
  namespace: galaxy
  name: demo-secret-01
stringData:
  demosecret01_01.py: |
    # False by default
    GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS = True
  demosecret01_02.py: |
    # False by default
    GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD = True
---
apiVersion: v1
kind: Secret
metadata:
  namespace: galaxy
  name: demo-secret-02
stringData:
  demosecret02_01.py: |
    GALAXY_COLLECTION_SIGNING_SERVICE = None
    GALAXY_CONTAINER_SIGNING_SERVICE = None
    TOKEN_AUTH_DISABLED = True
```

Result:

```bash

$ kubectl -n galaxy exec -it deployment/galaxy-api -- ls -l /etc/pulp/conf.d
total 16
-rw-r--r--. 1 root root 224 May 24 12:59 democonfigmap01_01.py
-rw-r--r--. 1 root root  74 May 24 12:59 demosecret01_01.py
-rw-r--r--. 1 root root  76 May 24 12:59 demosecret01_02.py
-rw-r--r--. 1 root root 108 May 24 13:06 demosecret02_01.py

$ kubectl -n galaxy exec -it deployment/galaxy-content -- ls -l /etc/pulp/conf.d
total 16
-rw-r--r--. 1 root 1000 224 May 24 12:59 democonfigmap01_01.py
-rw-r--r--. 1 root 1000  74 May 24 12:59 demosecret01_01.py
-rw-r--r--. 1 root 1000  76 May 24 12:59 demosecret01_02.py
-rw-r--r--. 1 root 1000 108 May 24 13:05 demosecret02_01.py

$ kubectl -n galaxy exec -it deployment/galaxy-worker -- ls -l /etc/pulp/conf.d
total 16
-rw-r--r--. 1 root root 224 May 24 12:59 democonfigmap01_01.py
-rw-r--r--. 1 root root  74 May 24 12:59 demosecret01_01.py
-rw-r--r--. 1 root root  76 May 24 12:59 demosecret01_02.py
-rw-r--r--. 1 root root 108 May 24 13:06 demosecret02_01.py

$ kubectl -n galaxy exec -it deployment/galaxy-api -- grep -r "" /etc/pulp/conf.d 
/etc/pulp/conf.d/demosecret02_01.py:GALAXY_COLLECTION_SIGNING_SERVICE = None
/etc/pulp/conf.d/demosecret02_01.py:GALAXY_CONTAINER_SIGNING_SERVICE = None
/etc/pulp/conf.d/demosecret02_01.py:TOKEN_AUTH_DISABLED = True
/etc/pulp/conf.d/demosecret01_02.py:# False by default
/etc/pulp/conf.d/demosecret01_02.py:GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD = True
/etc/pulp/conf.d/demosecret01_01.py:# False by default
/etc/pulp/conf.d/demosecret01_01.py:GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS = True
/etc/pulp/conf.d/democonfigmap01_01.py:GALAXY_FEATURE_FLAGS = {
/etc/pulp/conf.d/democonfigmap01_01.py:  "display_repositories": True,
/etc/pulp/conf.d/democonfigmap01_01.py:  # True by default so set False for testing
/etc/pulp/conf.d/democonfigmap01_01.py:  "execution_environments": False,
/etc/pulp/conf.d/democonfigmap01_01.py:  "legacy_roles": False,
/etc/pulp/conf.d/democonfigmap01_01.py:  "ai_deny_index": False,
/etc/pulp/conf.d/democonfigmap01_01.py:  "dab_resource_registry": False,
/etc/pulp/conf.d/democonfigmap01_01.py:}

$ kubectl -n galaxy exec -it deployment/galaxy-api -- cat /etc/pulp/settings.py
import os
import traceback

from split_settings.tools import optional, include

GALAXY_API_PATH_PREFIX = "api/galaxy"
CACHE_ENABLED = True
DB_ENCRYPTION_KEY = "/etc/pulp/keys/database_fields.symmetric.key"
GALAXY_COLLECTION_SIGNING_SERVICE = "ansible-default"
GALAXY_CONTAINER_SIGNING_SERVICE = "container-default"
ANSIBLE_CERTS_DIR = "/etc/pulp/keys/"
DATABASES = {"default": {"HOST": "galaxy-postgres-15", "ENGINE": "django.db.backends.postgresql_psycopg2", "NAME": "galaxy", "USER": "galaxy", "PASSWORD": "ZhMCgM3XJfyTLyjhMaf7hrkGjmi2NHWw", "PORT": "5432", "CONN_MAX_AGE": 0, "OPTIONS": {"sslmode": "prefer"}}}
STATIC_ROOT = "/app/galaxy_ng/app/static/"
REDIS_HOST = "galaxy-redis-svc"
REDIS_PORT = 6379
REDIS_PASSWORD = ""
CONTENT_ORIGIN = "http://192.168.0.221:30180"
ANSIBLE_API_HOSTNAME = "http://192.168.0.221:30180"
X_PULP_CONTENT_HOST = "galaxy-content-svc"
X_PULP_CONTENT_PORT = "24816"
TOKEN_SERVER = "http://192.168.0.221:30180/token/"
TOKEN_AUTH_DISABLED = False
TOKEN_SIGNATURE_ALGORITHM = "ES256"
PUBLIC_KEY_PATH = "/etc/pulp/keys/container_auth_public_key.pem"
PRIVATE_KEY_PATH = "/etc/pulp/keys/container_auth_private_key.pem"
CSRF_TRUSTED_ORIGINS = ["http://192.168.0.221:30180", "https://192.168.0.221:30180"]

# Attempt to load settings from /etc/pulp/conf.d/*.py.
settings_dir = os.environ.get('PULP_SETTINGS_DIR', '/etc/pulp/conf.d/')
settings_files = os.path.join(settings_dir, '*.py')
try:
    include(optional(settings_files), scope=locals())
except ImportError:
    traceback.print_exc()
    sys.exit(1)
```

I can confirm that additional settings in `*.py` take effects, e.g. browsing existing collections without logging in to the Galaxy by `GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS = True`.