### PR TITLE
Restore overrides patch

### DIFF
--- a/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
+++ b/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
@@ -44,6 +44,7 @@ spec:
         kubectl.kubernetes.io/default-container: api
 {% for secret in [
     "galaxy_server_secret",
+    "_postgres_configuration_secret",
     "db_fields_encryption_secret_contents",
   ] %}
         checksum-secret-{{ secret }}: "{{ lookup('ansible.builtin.vars', secret, default='')["resources"][0]["data"] | default('') | sha1 }}"

--- a/roles/galaxy-content/templates/galaxy-content.deployment.yaml.j2
+++ b/roles/galaxy-content/templates/galaxy-content.deployment.yaml.j2
@@ -52,6 +52,7 @@ spec:
 {% endif %}
 {% for secret in [
     "galaxy_server_secret",
+    "_postgres_configuration_secret",
     "db_fields_encryption_secret_contents",
   ] %}
         checksum-secret-{{ secret }}: "{{ lookup('ansible.builtin.vars', secret, default='')["resources"][0]["data"] | default('') | sha1 }}"

--- a/roles/galaxy-worker/templates/galaxy-worker.deployment.yaml.j2
+++ b/roles/galaxy-worker/templates/galaxy-worker.deployment.yaml.j2
@@ -45,6 +45,7 @@ spec:
         kubectl.kubernetes.io/default-container: worker
 {% for secret in [
     "galaxy_server_secret",
+    "_postgres_configuration_secret",
     "db_fields_encryption_secret_contents",
   ] %}
         checksum-secret-{{ secret }}: "{{ lookup('ansible.builtin.vars', secret, default='')["resources"][0]["data"] | default('') | sha1 }}"

--- a/roles/restore/tasks/secrets.yml
+++ b/roles/restore/tasks/secrets.yml
@@ -40,6 +40,18 @@
     - database_type is defined
     - database_type == 'managed'
 
+- name: Check if spec_overrides has postgres_configuration_secret specified
+  set_fact:
+    db_secret_exists: true
+  no_log: "{{ no_log }}"
+  when: spec_overrides['postgres_configuration_secret'] is defined
+
+- name: Combine spec_overrides database configuration secret
+  set_fact:
+    database_host: "{{ spec_overrides['postgres']}}"
+    cr_spec: "{{ cr_spec | default({}) | combine(spec_overrides) }}"
+  no_log: "{{ no_log }}"
+
 - name: Apply database configuration secret
   k8s:
     state: present
@@ -49,6 +61,7 @@
     - db_secret_name is defined
     - db_secret_name | length
     - database_password is defined
+    - not db_secret_exists
 
 - name: ls backup directory on PVC
   k8s_exec:

--- a/roles/restore/vars/main.yml
+++ b/roles/restore/vars/main.yml
@@ -14,3 +14,5 @@ pg_drop_create: ''
 
 is_k8s: false
 is_openshift: false
+
+db_secret_exists: false


### PR DESCRIPTION
##### SUMMARY

The value of `db_secret_name` was old, and was being used to create a pg secret, even when `spec_overrides.postgres_configuration_secret` was being set.  This was problematic for restores because if the overridden postgres configuration secret was named the same as the default, it would be overwritten.  

When `spec_overrides.postgres_configuration_secret` is set, we can safely assume the user has already created the specified secret in the namespace.  


```
sh-5.1# cat secrets.yaml 
---
admin_password_name: galaxy-admin-password
admin_password: p7OTqKveDredacted
database_password: U6muqyCredacted
database_username: galaxy
database_name: galaxy
database_port: 5432
database_host: galaxy-postgres-15
database_type: unmanaged
database_sslmode: prefer
postgres_version: 15
db_secret_name: galaxy-postgres-configuration
```

##### ADDITIONAL INFORMATION

Alternatively, we could take this opportunity to re-write the backup/restore role more so that it is more like the awx/eda operators, which do not have this issue.  (secret yaml would be stored in secrets.yaml in the backup pvc, not variables and their values)