### PR TITLE
backup: Remove default values for secret

### DIFF
--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -13,7 +13,6 @@ Role Variables
 * `backup_storage_requirements`: The size of storage for the PVC created by operator if one is not supplied
 * `backup_resource_requirements`: The size of storage for the PVC created by operator if one is not supplied
 * `backup_storage_class`: The storage class to be used for the backup PVC
-* `postgres_configuration_secret`: The postgres_configuration_secret
 
 
 Defining resources limits and request for backup CR

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -12,10 +12,6 @@ backup_storage_requirements: ''
 # Specify storage class to determine how to dynamically create PVC's with
 backup_storage_class: ''
 
-# Secret Names
-admin_password_secret: "{{ deployment_name }}-admin-password"
-postgres_configuration_secret: "{{ deployment_name }}-postgres-configuration"
-
 custom_resource_key: '_galaxy_ansible_com_galaxybackup'
 
 database_type: 'unmanaged'


### PR DESCRIPTION
##### SUMMARY

If we have default value for admin password and postgres configuration secrets then the backup CR status will be updated with those names during the reconciliation loop.
This breaks the backup/restore worfklow when using custom secret.

##### ADDITIONAL INFORMATION

- 1st backup execution:

`"databaseConfigurationSecret": "galaxy-external-database"`

- 2nd backup exection:

`"databaseConfigurationSecret": "example-galaxy-postgres-configuration"`

Later the restore will fail because the new deployment won't use the correct secret name.

This also removes the postgres_configuration_secret reference from the backup README because such parameter doesn't exist on this CRD.