### PR TITLE
Copy the correct path for artifacts and check if it exists first

### DIFF
--- a/roles/backup/templates/backup-content-k8s-job.yaml.j2
+++ b/roles/backup/templates/backup-content-k8s-job.yaml.j2
@@ -29,7 +29,9 @@ spec:
           - -c
           - |
             mkdir -p {{ _backup_dir }}/pulp
-            cp -fr /var/lib/pulp/{artifact,media,scripts} {{ _backup_dir }}/pulp/
+            if [ -d "/var/lib/pulp/media" ]; then cp -fr /var/lib/pulp/media {{ _backup_dir }}/pulp/; fi
+            if [ -d "/var/lib/pulp/media/artifact" ]; then cp -fr /var/lib/pulp/media/artifact {{ _backup_dir }}/pulp/; fi
+            if [ -d "/var/lib/pulp/scripts" ]; then cp -fr /var/lib/pulp/scripts {{ _backup_dir }}/pulp/; fi
 {% if backup_resource_requirements is defined %}
         resources:
           {{ backup_resource_requirements | to_nice_yaml(indent=2) | indent(width=10, first=False) }}


### PR DESCRIPTION
##### SUMMARY

This PR fixes some backup errors for galaxy.

This is what I see in the content pod after uploading 2 collections, everything looks good here:

```
sh-4.4$ ls -la /var/lib/pulp/     
total 4
drwxrwsrwx. 4 root       root   30 Jun 14 13:41 .
drwxr-xr-x. 1 root       root 4096 Jun 14 04:21 ..
drwxr-sr-x. 3 1000670000 root   22 Jun 14 13:52 media
drwxr-sr-x. 3 1000670000 root   49 Jun 14 13:54 tmp
sh-4.4$ ls -la /var/lib/pulp/media/artifact/
total 0
drwxr-sr-x. 4 1000670000 root 26 Jun 14 13:54 .
drwxr-sr-x. 3 1000670000 root 22 Jun 14 13:52 ..
drwxr-sr-x. 2 1000670000 root 76 Jun 14 13:54 8c
drwxr-sr-x. 2 1000670000 root 76 Jun 14 13:52 de
```

Permissions on the artifact itself is 0644, the artifact directory is 2755

So the media and tmp directories are good.  But backups expect artifacts and scripts directories to be in `/var/lib/pulp`.

artifacts is in /var/lib/media/artifacts and scripts is missing from my deployment because I don't have signing configured.

So on backup, the pod that mounts /var/lib/pulp and copies it to the backup, running:

```
cp -fr /var/lib/pulp/{artifact,media,scripts} /backups/openshift-backup-2024-06-14-140032/pulp/
But fails with:
cp: cannot stat '/var/lib/pulp/artifact': No such file or directory
cp: cannot stat '/var/lib/pulp/scripts': No such file or directory
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
