### PR TITLE
Set new db_secret_name value for managed pg restores

### DIFF
--- a/roles/restore/tasks/secrets.yml
+++ b/roles/restore/tasks/secrets.yml
@@ -27,13 +27,12 @@
   include_vars: "{{ tmp_secrets.path }}"
   no_log: "{{ no_log }}"
 
-
-
 - name: If deployment is managed, set the new postgres_configuration_secret name
   block:
   - name: Set new postgres_configuration_secret name
     set_fact:
       _generated_pg_secret_name: "{{ deployment_name }}-postgres-configuration"
+      db_secret_name: "{{ deployment_name }}-postgres-configuration"
 
   - name: Override postgres_configuration_secret
     set_fact:


### PR DESCRIPTION
##### SUMMARY

Fixes the following bug during pg restores...

```
[11:06](https://redhat-internal.slack.com/archives/DD5STBGQN/p1718809616543609)
TASK [Restore database dump to the new postgresql container] ********************************
fatal: [localhost]: FAILED! => {"changed": true, "rc": 1, "return_code": 1, "stderr": "pg_restore: error: could not translate host name \"mygalaxy-postgres-15\" to address: Name or service not known\nbash: line 12: 34 Terminated sleep 60\n", "stderr_lines": ["pg_restore: error: could not translate host name \"mygalaxy-postgres-15\" to address: Name or service not known", "bash: line 12: 34 Terminated sleep 60"], "stdout": "Migrating data from old database...\nkeepalive_pid: 32\n", "stdout_lines": ["Migrating data from old database...", "keepalive_pid: 32"]}
```

Now that I am cleaning up the original deployment before restoring when testing, I am seeing this error.  It is because the service is deleted.  So the restore-db-management-pod's pg_restore command has the wrong host set, because it is using the old postgres configuration secret.  This fixes that.  


##### ADDITIONAL INFORMATION
This problem is caused by the fact that we set `db_secret_name` based on the status on the backup object, but then we don't update that variable when we changes the secret name for managed deployments.

* https://github.com/ansible/galaxy-operator/blob/d91ce65955f5b296b1b76c10f57a11053f34f79f/roles/restore/tasks/init.yml#L47

So when it gets used when creating the management pod, it is incorrect and references the old pg secret.  