### PR TITLE
status: Add deployed version field

### DIFF
--- a/roles/galaxy-status/tasks/main.yml
+++ b/roles/galaxy-status/tasks/main.yml
@@ -188,6 +188,8 @@
     kind: "{{ kind }}"
     name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ ansible_operator_meta.namespace }}"
+    status:
+      deployedVersion: "{{ installed_plugins.galaxy }}"
 
 - name: Update image status
   operator_sdk.util.k8s_status:


### PR DESCRIPTION
##### SUMMARY
The `deployedVersion` status was present in the galaxy CRD and CSV file but the `k8s_status` task to update the version status wasn't doing anything.
This uses the galaxy version collected from the pulp status API endpoint.