### PR TITLE
Always set container token auth settings, even in the auth secret is generated

### DIFF
--- a/roles/galaxy-config/tasks/combine_galaxy_settings.yml
+++ b/roles/galaxy-config/tasks/combine_galaxy_settings.yml
@@ -20,7 +20,6 @@
   set_fact:
     content_origin_temp: pulp_settings.content_origin
   when:
-    - pulp_settings is defined
     - pulp_settings.content_origin is defined
 
 - name: Getting raw pulp_settings
@@ -38,6 +37,15 @@
 - include_tasks:
     file: get_node_ip.yml
   when: content_origin_temp is not defined
+
+- name: Set token_server and other container default settings
+  set_fact:
+    token_server_dict: "{ 'token_server': '{{ content_origin }}/token/', 'token_auth_disabled': 'False', 'token_signature_algorithm': 'ES256','public_key_path': '/etc/pulp/keys/container_auth_public_key.pem', 'private_key_path': '/etc/pulp/keys/container_auth_private_key.pem' }"
+
+- name: merge token_server with settings
+  set_fact:
+    default_settings: "{{ default_settings|combine(token_server_dict) }}"
+  no_log: "{{ no_log }}"
 
 - name: Set default CSRF_TRUSTED_ORIGINS to be used if not set by user
   set_fact:

--- a/roles/galaxy-config/tasks/get_node_ip.yml
+++ b/roles/galaxy-config/tasks/get_node_ip.yml
@@ -112,11 +112,6 @@
   set_fact:
     content_origin_dict: "{ 'content_origin': '{{ content_origin }}', 'ansible_api_hostname': '{{ ansible_api_hostname }}', 'x_pulp_content_host': '{{ content_host }}', 'x_pulp_content_port': '{{ content_port }}' }"
 
-- name: Set token_server and other container default settings
-  set_fact:
-    token_server_dict: "{ 'token_server': '{{ token_server }}', 'token_auth_disabled': 'False', 'token_signature_algorithm': 'ES256','public_key_path': '/etc/pulp/keys/container_auth_public_key.pem', 'private_key_path': '/etc/pulp/keys/container_auth_private_key.pem' }"
-  when: container_token_secret is defined
-
 - name: DEBUG Show content_origin_dict
   debug:
     msg: "{{ content_origin_dict }}"
@@ -125,13 +120,3 @@
   set_fact:
     default_settings: "{{ default_settings|combine(content_origin_dict) }}"
   no_log: "{{ no_log }}"
-
-- name: merge token_server with settings
-  set_fact:
-    default_settings: "{{ default_settings|combine(token_server_dict) }}"
-  no_log: "{{ no_log }}"
-  when: container_token_secret is defined
-
-- name: DEBUG Show content_origin
-  debug:
-    msg: "{{ default_settings.content_origin }}"


### PR DESCRIPTION

##### SUMMARY
Always set container token auth settings, even in the auth secret is generated

(enabling debug-3ci)
