### PR TITLE
Content origin temp var should be the same for both scenarios

### DIFF
--- a/roles/galaxy-config/tasks/combine_galaxy_settings.yml
+++ b/roles/galaxy-config/tasks/combine_galaxy_settings.yml
@@ -18,7 +18,7 @@
 # https://github.com/ansible/ansible/issues/50554
 - name: Setting CONTENT_ORIGIN
   set_fact:
-    content_origin_temp: pulp_settings.content_origin
+    content_origin: pulp_settings.content_origin
   when:
     - pulp_settings.content_origin is defined
 
@@ -36,7 +36,7 @@
 
 - include_tasks:
     file: get_node_ip.yml
-  when: content_origin_temp is not defined
+  when: content_origin is not defined
 
 - name: Set token_server and other container default settings
   set_fact:


### PR DESCRIPTION


##### SUMMARY
If the `pulp_settings.content_origin` is set by the user, we should set the temp content_orgin var so that it is used in the token_server_dict var, otherwise if the user sets this variable it will fail on the task that sets that dict.

Without this, the following error will be seen:

```
TASK [Set token_server and other container default settings] ******************************** 
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'content_origin' is undefined\n\nThe error appears to be in '/opt/ansible/roles/galaxy-config/tasks/combine_galaxy_settings.yml': line 41, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Set token_server and other container default settings\n  ^ here\n"}
```

If the user does not set `pulp_settings.content_origin`, content_origin is set in the `get_node_ip.yml` task.

##### ADDITIONAL INFORMATION

This is follow-up for https://github.com/ansible/galaxy-operator/pull/137/files, which introduced this regression.