### PR TITLE
Move force_drop_db param to restore CRD where it belongs

### DIFF
--- a/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
@@ -869,10 +869,6 @@ spec:
                         type: object
                     type: object
                 type: object
-              force_drop_db:
-                description: Force drop the database before restoring. USE WITH CAUTION!
-                type: boolean
-                default: false
             type: object
           status:
             properties:

--- a/config/crd/bases/galaxy_v1beta1_galaxyrestore_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxyrestore_crd.yaml
@@ -82,6 +82,10 @@ spec:
                   description: Overrides for the Galaxy spec
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                force_drop_db:
+                  default: false
+                  description: Force drop the database of the new Galaxy before restoring. USE WITH CAUTION!
+                  type: boolean
                 no_log:
                   default: true
                   description: Configure no_log (hides sensitive information in operator/task logs)

--- a/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
@@ -526,11 +526,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
-      - displayName: Force drop database before restore
-        path: force_drop_db
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - displayName: No Log Configuration
         path: no_log
         x-descriptors:
@@ -756,6 +751,11 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: No Log Configuration
         path: no_log
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: Force drop database before restore
+        path: force_drop_db
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch


### PR DESCRIPTION
##### SUMMARY
This param was added to the Galaxy CRD by mistake instead of the GalaxyRestore CRD.

