### PR TITLE
Deprecate redis.replicas as it is intentionally hardcoded to 1

### DIFF
--- a/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
@@ -340,7 +340,7 @@ spec:
                     type: string
                   replicas:
                     default: 1
-                    description: The number of replicas for the deployment.
+                    description: (Deprecated) The number of replicas for redis is 1
                     format: int32
                     type: integer
                   resource_requirements:

--- a/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
@@ -368,6 +368,12 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - description: (Deprecated) The number of Redis replicas
+        displayName: Replicas
+        path: redis.replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: API server configuration
         path: api
         x-descriptors:


### PR DESCRIPTION
##### SUMMARY
There's no "built in" logic for clustering or sentinel for Hub's internal redis.  Horizontal scaling (i.e., increasing replicas) does not automatically distribute cache data across the pods. Each replica would have its own independent cache, which means one pod won’t have access to the data cached by another pod. These inconsistencies could cause issues. 

Instead, you would need to use Redis Cluster for true horizontal scaling with distributed caching. Configuring an external Redis should be a future RFE to satisfy this request.

As a result, we should deprecate this field so it does not confuse users. 