### PR TITLE
Add Development scripts with ansible- prefix for now

### DIFF
--- a/.ci/scripts/backup_and_restore.sh
+++ b/.ci/scripts/backup_and_restore.sh
@@ -78,9 +78,9 @@ password password\
 export BASE_ADDR="http://$SERVER:$WEB_PORT"
 echo $BASE_ADDR
 
-if [ -z "$(pip freeze | grep pulp-cli)" ]; then
+if [ -z "$(python3 -m pip freeze | grep pulp-cli)" ]; then
   echo "Installing pulp-cli"
-  pip install pulp-cli[pygments]==0.23.0
+  python3 -m pip install pulp-cli[pygments]==0.23.0
 fi
 
 if [[ "$CI_TEST" == "galaxy" ]]; then

--- a/.ci/scripts/galaxy_ng-tests.sh
+++ b/.ci/scripts/galaxy_ng-tests.sh
@@ -4,17 +4,17 @@ set -euo pipefail
 KUBE="k3s"
 SERVER=$(hostname)
 WEB_PORT="24817"
-if [[ "${1-null}" == "--minikube" ]] || [[ "${1-null}" == "-m" ]]; then
+if [[ "$1" == "--minikube" ]] || [[ "$1" == "-m" ]]; then
   KUBE="minikube"
   SERVER="localhost"
-  if [[ "$CI_TEST" == "true" ]]; then
+  if [[ "$CI_TEST" == "true" ]] || [[ "$CI_TEST" == "galaxy" ]]; then
     SVC_NAME="example-galaxy-web-svc"
     WEB_PORT="24880"
     kubectl port-forward service/$SVC_NAME $WEB_PORT:$WEB_PORT &
   fi
 fi
 
-pip3 install "ansible<2.13.2"
+python3 -m pip install "ansible<2.13.2"
 
 BASE_ADDR="http://$SERVER:$WEB_PORT"
 echo $BASE_ADDR
@@ -52,10 +52,10 @@ do
     fi
 done
 
-podman pull registry.access.redhat.com/ubi9/ubi-micro:latest
-podman login --tls-verify=false -u admin -p password localhost:24880
-podman tag registry.access.redhat.com/ubi9/ubi-micro:latest localhost:24880/ubi9-micro:latest 
-podman push --tls-verify=false localhost:24880/ubi9-micro:latest
+sudo podman pull registry.access.redhat.com/ubi9/ubi-micro:latest
+sudo podman login --tls-verify=false -u admin -p password localhost:24880
+sudo podman tag registry.access.redhat.com/ubi9/ubi-micro:latest localhost:24880/ubi9-micro:latest
+sudo podman push --tls-verify=false localhost:24880/ubi9-micro:latest
 
 
 curl -H "Authorization:Token $TOKEN" http://localhost:24880/api/galaxy/v3/plugin/execution-environments/repositories/ | jq

--- a/.ci/scripts/galaxy_tests.sh
+++ b/.ci/scripts/galaxy_tests.sh
@@ -24,7 +24,7 @@ password password\
 export BASE_ADDR="http://$SERVER:$WEB_PORT"
 echo $BASE_ADDR
 
-pip install pulp-cli==0.23.0
+python3 -m pip install pulp-cli==0.23.0
 
 if [ ! -f ~/.config/pulp/settings.toml ]; then
   echo "Configuring pulp-cli"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,12 @@ jobs:
           # by default, it uses a depth of 1
           # this fetches all history so that we can read each commit
           fetch-depth: 0
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
         with:
-          python-version: '3.8'
+          python-version: '3.9'
+
       - name: Install httpie
         run: |
           echo ::group::HTTPIE
@@ -123,7 +125,7 @@ jobs:
         shell: bash
 
       - name: Test
-        run: sudo -E .ci/scripts/galaxy_ng-tests.sh -m
+        run: CI_TEST=galaxy .ci/scripts/galaxy_ng-tests.sh -m
         shell: bash
 
       - name: Backup & Restore

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,10 +44,10 @@ jobs:
           # repository: ${{ steps.head_repo_name.outputs.repo }}
           # ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v1
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install httpie
         run: |
@@ -128,7 +128,7 @@ jobs:
           sudo popeye --kubeconfig ~/.kube/config || true
 
       - name: Test
-        run: sudo -E .ci/scripts/galaxy_ng-tests.sh -m
+        run: CI_TEST=galaxy .ci/scripts/galaxy_ng-tests.sh -m
         shell: bash
 
       - name: Backup & Restore

--- a/.github/workflows/stage.yaml
+++ b/.github/workflows/stage.yaml
@@ -45,13 +45,13 @@ jobs:
           repository: ${{ github.repository_owner }}/galaxy-operator
           path: galaxy-operator
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
         with:
-          python-version: '3.x'
+          python-version: '3.9'
 
       - name: Install dependencies
-        run: pip install requests
+        run: python3 -m pip install requests
 
       - name: Install playbook dependencies
         run: |

--- a/ansible-down.sh
+++ b/ansible-down.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Galaxy Operator ansible-down.sh
+
+# -- Usage
+#   NAMESPACE=galaxy ./ansible-down.sh
+#
+# -- User Environment Variables
+# export NAMESPACE=testme                   # Namespace to deploy to
+# export QUAY_USER=chadams                  # Quay.io username to push operator image to
+
+
+# -- Variables
+TAG=${TAG:-dev}
+IMG=quay.io/$QUAY_USER/galaxy-operator:$TAG
+
+if [ -z "$QUAY_USER" ]; then
+  echo "Error: QUAY_USER env variable is not set."
+  echo "  export QUAY_USER=developer"
+
+  exit 1
+fi
+if [ -z "$NAMESPACE" ]; then
+  echo "Error: NAMESPACE env variable is not set. Run the following with your namespace:"
+  echo "  export NAMESPACE=developer"
+  exit 1
+fi
+
+
+# Delete Custom Resources
+oc delete galaxyrestore --all -n $NAMESPACE
+oc delete galaxybackup --all -n $NAMESPACE
+oc delete galaxy --all -n $NAMESPACE
+
+# Delete Secrets
+oc delete secrets --all -n $NAMESPACE
+
+# Delete old operator deployment
+oc delete deployment galaxy-operator-controller-manager -n $NAMESPACE
+
+# Deploy Operator
+make undeploy IMG=$IMG NAMESPACE=$NAMESPACE
+
+# Delete Azurite Storage
+oc delete -f hacking/azurite/azurite.yaml
+
+# Delete tls and ca certs
+rm -rf ./hacking/ca-cert/*
+rm -rf ./hacking/tls-azurite/*
+rm -rf ./hacking/tls-galaxy/*
+
+# Remove PVCs
+oc delete pvc --all -n $NAMESPACE
+

--- a/ansible-up.sh
+++ b/ansible-up.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Galaxy-Operator ansible-up.sh
+
+# -- Usage
+#   NAMESPACE=gateway TAG=dev QUAY_USER=developer ./ansible-up.sh
+#
+# -- User Environment Variables
+# export NAMESPACE=testme                   # Namespace to deploy to
+# export QUAY_USER=developer                # Quay.io username to push operator image to
+
+
+# -- Variables
+TAG=${TAG:-dev}
+
+IMG=${IMG:-"quay.io/$QUAY_USER/galaxy-operator:$TAG"}
+
+if [ -z "$QUAY_USER" ]; then
+  echo "Error: QUAY_USER env variable is not set."
+  echo "  export QUAY_USER=developer"
+
+  exit 1
+fi
+if [ -z "$NAMESPACE" ]; then
+  echo "Error: NAMESPACE env variable is not set. Run the following with your namespace:"
+  echo "  export NAMESPACE=developer"
+  exit 1
+fi
+
+
+# -- Prepare
+
+# Set imagePullPolicy to Always
+
+# Set default in manifest and crd files
+files=(
+    config/manager/manager.yaml
+)
+for file in "${files[@]}"; do
+  if ! grep -qF 'imagePullPolicy:' ${file}; then
+    sed -i -e "/image: controller:latest/a \\
+        imagePullPolicy: Always" ${file};
+  fi
+done
+
+# Set imagePullPolicy to Always
+files=(
+    config/manager/manager.yaml
+)
+for file in "${files[@]}"; do
+  if grep -qF 'imagePullPolicy: IfNotPresent' ${file}; then
+    sed -i -e "s|imagePullPolicy: IfNotPresent|imagePullPolicy: Always|g"  ${file};
+  fi
+done
+
+
+# -- Wait for existing project to be deleted
+
+# Function to check if the namespace is in terminating state
+is_namespace_terminating() {
+    kubectl get namespace $NAMESPACE 2>/dev/null | grep -q 'Terminating'
+    return $?
+}
+
+# Check if the namespace exists and is in terminating state
+if kubectl get namespace $NAMESPACE 2>/dev/null; then
+    echo "Namespace $NAMESPACE exists."
+
+    if is_namespace_terminating; then
+        echo "Namespace $NAMESPACE is in terminating state. Waiting for it to be fully terminated..."
+        while is_namespace_terminating; do
+            sleep 5
+        done
+        echo "Namespace $NAMESPACE has been terminated."
+    fi
+fi
+
+
+# -- Create namespace
+# oc new-project $NAMESPACE
+kubectl create namespace $NAMESPACE
+
+# -- Delete old operator deployment
+kubectl delete deployment galaxy-operator-controller-manager
+
+# -- Create Pull Secret
+kubectl create secret generic redhat-operators-pull-secret --from-file=.dockerconfigjson=$HOME/.docker/config.json --type=kubernetes.io/dockerconfigjson
+
+# -- Create Secrets for data migration if desired
+kubectl apply -f dev/admin-password-secret.yml
+
+
+# -- Build & Push Operator Image
+make docker-build docker-push IMG=$IMG
+
+# -- Deploy Pulp Operator
+echo "Make Deploy"
+make deploy IMG=$IMG NAMESPACE=$NAMESPACE
+
+# -- CI assets
+# kubectl apply -f .ci/assets/kubernetes/galaxy_sign.secret.yaml
+# kubectl apply -f .ci/assets/kubernetes/signing_scripts.configmap.yaml
+# kubectl apply -f .ci/assets/kubernetes/pulp-admin-password.secret.yaml
+# sed -i '/file_storage_access_mode:/c\  file_storage_access_mode: ReadWriteOnce' config/samples/pulpproject_v1beta1_pulp_cr.galaxy.ci.yaml
+# kubectl create -f config/samples/pulpproject_v1beta1_pulp_cr.galaxy.ci.yaml # CI CR
+
+
+# Signing Configurations
+kubectl apply -f .ci/assets/kubernetes/galaxy_sign.secret.yaml
+kubectl apply -f .ci/assets/kubernetes/signing_scripts.configmap.yaml
+
+echo "Create Galaxy Custom Resource Object"
+kubectl create -f dev/galaxy.cr.yml
+
+
+

--- a/dev/admin-password-secret.yml
+++ b/dev/admin-password-secret.yml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: 'admin-password-secret'
+stringData:
+  password: 'password'
+

--- a/dev/galaxy.cr.yml
+++ b/dev/galaxy.cr.yml
@@ -1,0 +1,77 @@
+---
+apiVersion: galaxy.ansible.com/v1beta1
+kind: Galaxy
+metadata:
+  name: galaxy
+  namespace: galaxy
+spec:
+  
+  # ingress_type: nodeport
+  # nodeport_port: 32002
+  ingress_type: Route
+  deployment_type: galaxy
+
+  image_pull_policy: Always
+  no_log: false
+
+  # Test CA Bundle
+  # bundle_cacert_secret: my-custom-certs
+  # route_tls_secret: galaxy-tls
+
+  # signing configuration
+  signing_secret: "signing-galaxy"
+  signing_scripts_configmap: "signing-scripts"
+
+  # admin_password_secret: admin-password-secret
+
+  #object_storage_azure_secret: automation-hub-azurite
+  #storage_type: Azure
+
+  storage_type: File
+
+  # k3s local-path requires this
+  file_storage_access_mode: "ReadWriteMany"
+  # # We have a little over 10GB free on GHA VMs/instances
+  file_storage_size: "10Gi"
+  file_storage_storage_class: nfs-local-rwx
+  
+  pulp_settings:
+    api_root: "/api/galaxy/pulp/"
+    allowed_export_paths:
+      - /tmp
+    allowed_import_paths:
+      - /tmp
+    telemetry: false
+
+  # database:
+  #   postgres_storage_class: standard
+  # api:
+  #   replicas: 1
+  # content:
+  #   replicas: 1
+  #   resource_requirements:
+  #     requests:
+  #       cpu: 150m
+  #       memory: 256Mi
+  #     limits:
+  #       cpu: 800m
+  #       memory: 1Gi
+  # worker:
+  #   replicas: 1
+  #   resource_requirements:
+  #     requests:
+  #       cpu: 150m
+  #       memory: 256Mi
+  #     limits:
+  #       cpu: 800m
+  #       memory: 1Gi
+  # web:
+  #   replicas: 1
+  #   resource_requirements:
+  #     requests:
+  #       cpu: 100m
+  #       memory: 256Mi
+  #     limits:
+  #       cpu: 800m
+  #       memory: 1Gi
+

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -11,6 +11,11 @@ If a task cannot be made idempotent, add the tag [molecule-idempotence-notest](h
 3. Push your branch to your fork and open a [Pull request across forks.](https://help.github.com/articles/creating-a-pull-request-from-a-fork/)
 4. Add GitHub labels as appropriate.
 
+Development Guide
+-----------------
+
+See the Openshift [development guide](./development.md) for details on how to deploy on Openshift.
+
 Docs Testing
 ------------
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,44 @@
+# Development Guide
+
+There are development scripts and yaml examples in the [`dev/`](../dev) directory that, along with the ansible-up.sh and ansible-down.sh scripts in the root of the repo, can be used to build, deploy and test changes made to the gateway operator.
+
+
+## Build and Deploy
+
+
+If you clone the repo, and make sure you are logged in at the CLI with oc and your cluster, you can run:
+
+```
+export QUAY_USER=username
+export NAMESPACE=galaxy
+export TAG=test
+./ansible-up.sh
+```
+
+You can add those variables to your .bashrc file so that you can just run `./ansible-up.sh` in the future.
+
+> Note: the first time you run this, it will create quay.io repos on your fork. You will need to either make those public, or create a global pull secret on your Openshift cluster.
+
+About 5 minutes after the script completes, you will have a fully functional Galaxy deployment. To get the URL:
+
+```bash
+oc get route
+```
+
+To get the admin password:
+
+```bash
+oc get secret admin-password-secret -o jsonpath={.data.password} | base64 --decode
+```
+
+
+## Clean up
+
+
+Same thing for cleanup, just run ./ansible-down.sh and it will clean up your namespace on that cluster
+
+
+```
+./ansible-down.sh
+```
+


### PR DESCRIPTION
##### SUMMARY

Eventually, I want to rewrite our CI (which currently depends on the up.sh and down.sh committed to the repo), then add the scripts I just shared here instead.  That way the galaxy-operator will be exactly like the other 5 operators.

But for now, I'll just add these scripts with the `ansible-` prefix so they don't conflict.

##### ADDITIONAL INFORMATION

Usage:

```
export QUAY_USER=username
export NAMESPACE=galaxy
export TAG=test
./ansible-up.sh
```
