### PR TITLE
Specify sslrootcert in database options

### DIFF
--- a/playbooks/galaxy.yaml
+++ b/playbooks/galaxy.yaml
@@ -24,6 +24,7 @@
           CONN_MAX_AGE: 0
           OPTIONS:
             sslmode: '{{ postgres_sslmode }}'
+            sslrootcert: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
       static_root: /app/galaxy_ng/app/static/
       redis_host: "{{ ansible_operator_meta.name }}-redis-svc"
       redis_port: 6379

--- a/playbooks/galaxy.yaml
+++ b/playbooks/galaxy.yaml
@@ -24,7 +24,7 @@
           CONN_MAX_AGE: 0
           OPTIONS:
             sslmode: '{{ postgres_sslmode }}'
-            sslrootcert: "{{'/etc/pki/tls/certs/ca-bundle.crt' if (postgres_sslmode in ['verify-ca', 'verify-full'])}}"
+            sslrootcert: "{{'/etc/pki/tls/certs/ca-bundle.crt' if (postgres_sslmode in ['verify-ca', 'verify-full']) else ''}}"
       static_root: /app/galaxy_ng/app/static/
       redis_host: "{{ ansible_operator_meta.name }}-redis-svc"
       redis_port: 6379

--- a/playbooks/galaxy.yaml
+++ b/playbooks/galaxy.yaml
@@ -24,7 +24,7 @@
           CONN_MAX_AGE: 0
           OPTIONS:
             sslmode: '{{ postgres_sslmode }}'
-            sslrootcert: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
+            sslrootcert: "{{'/etc/pki/tls/certs/ca-bundle.crt' if (postgres_sslmode in ['verify-ca', 'verify-full'])}}"
       static_root: /app/galaxy_ng/app/static/
       redis_host: "{{ ansible_operator_meta.name }}-redis-svc"
       redis_port: 6379


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adds sslrootcert in the database options pointing to the volume mount of the bundle_cacert_secret. This allows a custom CA to be used if sslmode is set to `verify-ca` or `verify-full` in the postgres_configuration_secret.

Issue: AAP-32390

