### PR TITLE
route: Use explicit api version

### DIFF
--- a/roles/galaxy-route/tasks/main.yml
+++ b/roles/galaxy-route/tasks/main.yml
@@ -18,7 +18,7 @@
 - name: "Remove deprecated {{ deployment_type }} Routes when present for {{ ansible_operator_meta.name }} from {{ ansible_operator_meta.namespace }} namespace"
   kubernetes.core.k8s:
     state: absent
-    api_version: v1
+    api_version: route.openshift.io/v1
     kind: Route
     namespace: "{{ ansible_operator_meta.namespace }}"
     name: "{{ item }}"


### PR DESCRIPTION
##### SUMMARY

This change the api version from v1 to route.openshift.io/v1 to avoid issue when using kubevirt.

##### ADDITIONAL INFORMATION

All other tasks related to `kind: Route` are already using this.
This is similar to what was done in 4b526eb.
