### PR TITLE
Check that deployedVersion status is defined to avoid failures

### DIFF
--- a/roles/common/tasks/check_existing.yml
+++ b/roles/common/tasks/check_existing.yml
@@ -12,7 +12,9 @@
     - name: Set previous_version version based on {{ deployment_type }} CR version status
       ansible.builtin.set_fact:
         previous_version: "{{ existing_deployment.resources[0].status.deployedVersion }}"
-      when: existing_deployment['resources'] | length > 0
+      when:
+        - existing_deployment.resources | length > 0
+        - existing_deployment.resources[0].status.deployedVersion
 
 - name: Check previous_version against gating_version if defined
   block:


### PR DESCRIPTION
##### SUMMARY

We should add a check loop for the upgrade test script, but we should also make sure this doesn't fail in the hub operator by checking that the status exists first.

```
[common : Set previous_version version based on automationhub CR version status] ***\r\n\u001b[1;30mtask path: /opt/ansible/roles/common/tasks/check_existing.yml:12\u001b[0m\n\u001b[0;31mfatal: [localhost]: FAILED! => {\"msg\": \"The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'deployedVersion'
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
