### PR TITLE
Add back force_drop_db to avoid validation error upon upgrade

### DIFF
--- a/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
@@ -151,6 +151,10 @@ spec:
               postgres_label_selector:
                 description: Label selector used to identify postgres pod for executing migration
                 type: string
+              force_drop_db:
+                default: false
+                description: (Deprecated) Force drop the database of the new Galaxy before restoring. USE WITH CAUTION!
+                type: boolean
               no_log:
                 default: true
                 description: Configure no_log for no_log tasks

--- a/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
@@ -528,6 +528,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
+      - displayName: Force drop database before restore
+        path: force_drop_db
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - displayName: Container token configuration
         path: container_token_secret
         x-descriptors:


### PR DESCRIPTION
##### SUMMARY

Add back force_drop_db to avoid validation error upon upgrade.

If a user had force_drop_db parameter set in a prior version, upon upgrade this would throw a validation error:

```
  strict decoding error: unknown field "spec.force_drop_db"
```

