### PR TITLE
Check if deployedVersion is defined in status before eval

### DIFF
--- a/roles/common/tasks/check_existing.yml
+++ b/roles/common/tasks/check_existing.yml
@@ -14,6 +14,7 @@
         previous_version: "{{ existing_deployment.resources[0].status.deployedVersion }}"
       when:
         - existing_deployment.resources | length > 0
+        - existing_deployment.resources[0].status.deployedVersion is defined
         - existing_deployment.resources[0].status.deployedVersion
 
 - name: Check previous_version against gating_version if defined


### PR DESCRIPTION
##### SUMMARY

```
The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'deployedVersion'
```

Fixes https://issues.redhat.com/browse/AAP-33810