### PR TITLE
Fix disable reverse sync on mgmt command

### DIFF
--- a/roles/galaxy-api/tasks/resource_configuration.yml
+++ b/roles/galaxy-api/tasks/resource_configuration.yml
@@ -44,7 +44,7 @@
     namespace: "{{ ansible_operator_meta.namespace }}"
     pod: "{{ _api_pod_name }}"
     container: "api"
-    command: bash -c "pulpcore-manager reset-admin-password --password '{{ admin_password }}'"
+    command: bash -c "ANSIBLE_REVERSE_RESOURCE_SYNC=false pulpcore-manager reset-admin-password --password '{{ admin_password }}'"
   register: result
   changed_when: "'That username is already taken' not in result.stderr"
   failed_when: "'That username is already taken' not in result.stderr and 'Successfully set password' not in result.stdout"


### PR DESCRIPTION
##### SUMMARY

environment does not get pass into command for k8s exec

Related: https://github.com/ansible/awx-operator/pull/1977

##### ADDITIONAL INFORMATION

Thankfully, we've already done this in the eda operator:
* https://github.com/ansible/eda-server-operator/blob/main/roles/eda/tasks/create_admin_user.yml#L22