### PR TITLE
Check that previous_version is defined before continuing

### DIFF
--- a/roles/common/tasks/check_existing.yml
+++ b/roles/common/tasks/check_existing.yml
@@ -23,6 +23,7 @@
       ansible.builtin.set_fact:
         upgraded_from: "{{ previous_version }}"
       when:
+        - previous_version is defined
         - previous_version is version(gating_version, '<')
 
   when: gating_version | length


### PR DESCRIPTION
##### SUMMARY

This happens when the `deployedVersion` label is not set on the hub CR.

```
[localhost]: FAILED! => {\"msg\": \"The conditional check 'previous_version is version(gating_version, '<')' failed. The error was: Version comparison: 'previous_version' is undefined\\n\\nThe error appears to be in '/opt/ansible/roles/common/tasks/check_existing.yml': line 22, column 7, but may\\nbe elsewhere in the file depending on the exact syntax problem.\\n\\nThe offending line appears to be:\\n\\n\\n    - name: Set upgraded_from to previous_version ({{ previous_version }}) if older than gating_version ({{ gating_version }})
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
