### PR TITLE
Add deployedVersion if not set

### DIFF
--- a/roles/common/tasks/check_existing.yml
+++ b/roles/common/tasks/check_existing.yml
@@ -1,23 +1,40 @@
 ---
-- name: Check for existing {{ deployment_type }} deployment
+- name: Check if {{ kind }} CR exists by name
+  kubernetes.core.k8s_info:
+    kind: "{{ kind }}"
+    api_version: '{{ api_version }}'
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: '{{ ansible_operator_meta.namespace }}'
+  register: existing_deployment
+
+- name: Set previous_version if deployment exists
+  when: existing_deployment.resources | length > 0
   block:
-    - name: Check if {{ kind }} CR exists by name
-      kubernetes.core.k8s_info:
-        kind: "{{ kind }}"
-        api_version: '{{ api_version }}'
-        name: "{{ ansible_operator_meta.name }}"
-        namespace: '{{ ansible_operator_meta.namespace }}'
-      register: existing_deployment
+    - name: Update previous existing deployment without version
+      when: existing_deployment.resources[0].status.deployedVersion is not defined
+      block:
+        - name: Get galaxy settings
+          ansible.builtin.include_role:
+            name: galaxy-config
+            tasks_from: combine_galaxy_settings.yml
+
+        - name: Set deployedVersion if not present
+          ansible.builtin.include_role:
+            name: galaxy-status
+            tasks_from: version.yml
+
+        - name: Check the updated {{ kind }} CR
+          kubernetes.core.k8s_info:
+            kind: "{{ kind }}"
+            api_version: '{{ api_version }}'
+            name: "{{ ansible_operator_meta.name }}"
+            namespace: '{{ ansible_operator_meta.namespace }}'
+          register: existing_deployment
 
     - name: Set previous_version version based on {{ deployment_type }} CR version status
       ansible.builtin.set_fact:
         previous_version: "{{ existing_deployment.resources[0].status.deployedVersion }}"
-      when:
-        - existing_deployment.resources | length > 0
-        - existing_deployment.resources[0].status.deployedVersion is defined
-
-- name: Check previous_version against gating_version if defined
-  block:
+      when: existing_deployment.resources[0].status.deployedVersion is defined
 
     - name: Set upgraded_from to previous_version ({{ previous_version }}) if older than gating_version ({{ gating_version }})
       ansible.builtin.set_fact:
@@ -25,5 +42,4 @@
       when:
         - previous_version is defined
         - previous_version is version(gating_version, '<')
-
-  when: gating_version | length
+...

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -13,10 +13,6 @@
     api_version: '{{ hostvars["localhost"]["inventory_file"].split("/")[4:6] | join("/")  }}'
     kind: '{{ hostvars["localhost"]["inventory_file"].split("/")[6]  }}'
 
-- name: Check for existing {{ deployment_type }} deployment
-  ansible.builtin.include_tasks: check_existing.yml
-  when: gating_version | length
-
 - name: Fail execution if image_pull_secret or image_pull_secrets are defined but as NoneType ('image_pull_secret[s]:')
   fail:
     msg: "If image_pull_secret or image_pull_secrets will not be used, their declarations should be removed."
@@ -62,6 +58,10 @@
     set_fact:
       web_url: "https://{{ route_host }}"
   when: ingress_type | lower == 'route'
+
+- name: Check for existing {{ deployment_type }} deployment
+  ansible.builtin.include_tasks: check_existing.yml
+  when: gating_version | length
 
 - name: Configure Postgres Configuration Secret
   include_tasks: postgres_configuration.yml

--- a/roles/galaxy-status/tasks/main.yml
+++ b/roles/galaxy-status/tasks/main.yml
@@ -43,58 +43,8 @@
   when:
     - ingress_type | lower != 'route'
 
-- name: Set the status protocol and port
-  set_fact:
-    status_protocol: "https"
-    status_port: "8443"
-  when:
-    - ingress_type | lower == 'route'
-    - route_tls_termination_mechanism | lower == 'passthrough'
-
-- name: Check, through galaxy-web, if the app is ready to serve requests
-  uri:
-    url: '{{ status_protocol }}://{{ ansible_operator_meta.name }}-web-svc.{{ ansible_operator_meta.namespace }}.svc.cluster.local:{{ status_port }}/{{ pulp_combined_settings.galaxy_api_path_prefix }}/pulp/api/v3/status/'
-  register: result_not_route
-  until: >
-    result_not_route.json is defined and
-    result_not_route.json.versions | length and
-    result_not_route.json.online_content_apps | length and
-    result_not_route.json.database_connection.connected and
-    (result_not_route.json.redis_connection.connected or not pulp_combined_settings.cache_enabled) and
-    result_not_route.json.online_workers | map(attribute='name') | select('match', '^[0-9]+@.*$') | list | count > 0
-  delay: 5
-  retries: 10
-  when:
-    - ingress_type | lower != 'route'
-
-- name: Check, through galaxy-route, if the app is ready to serve requests
-  uri:
-    url: 'https://{{ route_host }}/{{ pulp_combined_settings.galaxy_api_path_prefix }}/pulp/api/v3/status/'
-    validate_certs: no
-  register: result_route
-  until: >
-    result_route.json is defined and
-    result_route.json.versions | length and
-    result_route.json.online_content_apps | length and
-    result_route.json.database_connection.connected and
-    (result_route.json.redis_connection.connected or not pulp_combined_settings.cache_enabled) and
-    result_route.json.online_workers | map(attribute='name') | select('match', '^[0-9]+@.*$') | list | count > 0
-  delay: 5
-  retries: 60
-  when:
-    - ingress_type | lower == 'route'
-
-# Workaround to issue https://github.com/ansible/ansible/issues/76176
-- set_fact:
-    result: "{{ result_route.json is defined | ternary(result_route, result_not_route) }}"
-
-- name: Get installed plugins
-  set_fact:
-    installed_plugins: "{{ result.json.versions | items2dict(key_name='component', value_name='version') }}"
-
-- name: Show installed plugins
-  debug:
-    var: installed_plugins
+- name: Manage deployed version
+  ansible.builtin.include_tasks: version.yml
 
 - name: Remove resource manager deployment
   kubernetes.core.k8s:
@@ -191,15 +141,6 @@
     status:
       upgradedFrom: "{{ upgraded_from }}"
   when: upgraded_from is defined
-
-- name: Update version status
-  operator_sdk.util.k8s_status:
-    api_version: '{{ api_version }}'
-    kind: "{{ kind }}"
-    name: "{{ ansible_operator_meta.name }}"
-    namespace: "{{ ansible_operator_meta.namespace }}"
-    status:
-      deployedVersion: "{{ installed_plugins.galaxy }}"
 
 - name: Update image status
   operator_sdk.util.k8s_status:

--- a/roles/galaxy-status/tasks/version.yml
+++ b/roles/galaxy-status/tasks/version.yml
@@ -1,0 +1,63 @@
+---
+- name: Set the status protocol and port
+  set_fact:
+    status_protocol: "https"
+    status_port: "8443"
+  when:
+    - ingress_type | lower == 'route'
+    - route_tls_termination_mechanism | lower == 'passthrough'
+
+- name: Check, through galaxy-web, if the app is ready to serve requests
+  uri:
+    url: '{{ status_protocol }}://{{ ansible_operator_meta.name }}-web-svc.{{ ansible_operator_meta.namespace }}.svc.cluster.local:{{ status_port }}/{{ pulp_combined_settings.galaxy_api_path_prefix }}/pulp/api/v3/status/'
+  register: result_not_route
+  until: >
+    result_not_route.json is defined and
+    result_not_route.json.versions | length and
+    result_not_route.json.online_content_apps | length and
+    result_not_route.json.database_connection.connected and
+    (result_not_route.json.redis_connection.connected or not pulp_combined_settings.cache_enabled) and
+    result_not_route.json.online_workers | map(attribute='name') | select('match', '^[0-9]+@.*$') | list | count > 0
+  delay: 5
+  retries: 10
+  when:
+    - ingress_type | lower != 'route'
+
+- name: Check, through galaxy-route, if the app is ready to serve requests
+  uri:
+    url: 'https://{{ route_host }}/{{ pulp_combined_settings.galaxy_api_path_prefix }}/pulp/api/v3/status/'
+    validate_certs: no
+  register: result_route
+  until: >
+    result_route.json is defined and
+    result_route.json.versions | length and
+    result_route.json.online_content_apps | length and
+    result_route.json.database_connection.connected and
+    (result_route.json.redis_connection.connected or not pulp_combined_settings.cache_enabled) and
+    result_route.json.online_workers | map(attribute='name') | select('match', '^[0-9]+@.*$') | list | count > 0
+  delay: 5
+  retries: 60
+  when:
+    - ingress_type | lower == 'route'
+
+# Workaround to issue https://github.com/ansible/ansible/issues/76176
+- set_fact:
+    result: "{{ result_route.json is defined | ternary(result_route, result_not_route) }}"
+
+- name: Get installed plugins
+  set_fact:
+    installed_plugins: "{{ result.json.versions | items2dict(key_name='component', value_name='version') }}"
+
+- name: Show installed plugins
+  debug:
+    var: installed_plugins
+
+- name: Update version status
+  operator_sdk.util.k8s_status:
+    api_version: '{{ api_version }}'
+    kind: "{{ kind }}"
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    status:
+      deployedVersion: "{{ installed_plugins.galaxy }}"
+...


### PR DESCRIPTION
##### SUMMARY

If an existing deployment doesn't have the deployedVersion status set then we can force this to be set at the beginning of the operator execution.
This will help determine if there's an upgrade needed or not.