### PR TITLE
Add deployedVersion is not set

### DIFF
--- a/roles/common/tasks/check_existing.yml
+++ b/roles/common/tasks/check_existing.yml
@@ -1,23 +1,41 @@
 ---
-- name: Check for existing {{ deployment_type }} deployment
+- name: Check if {{ kind }} CR exists by name
+  kubernetes.core.k8s_info:
+    kind: "{{ kind }}"
+    api_version: '{{ api_version }}'
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: '{{ ansible_operator_meta.namespace }}'
+  register: existing_deployment
+
+- name: Set previous_version if deployment exists
+  when:
+    - gating_version | length
+    - existing_deployment.resources | length > 0
   block:
-    - name: Check if {{ kind }} CR exists by name
-      kubernetes.core.k8s_info:
-        kind: "{{ kind }}"
-        api_version: '{{ api_version }}'
-        name: "{{ ansible_operator_meta.name }}"
-        namespace: '{{ ansible_operator_meta.namespace }}'
-      register: existing_deployment
+    - name: Update previous existing deployment without version
+      when: existing_deployment.resources[0].status.deployedVersion is not defined
+      block:
+        - name: Update version status
+          operator_sdk.util.k8s_status:
+            api_version: '{{ api_version }}'
+            kind: "{{ kind }}"
+            name: "{{ ansible_operator_meta.name }}"
+            namespace: "{{ ansible_operator_meta.namespace }}"
+            status:
+              deployedVersion: "4.9.2"
+
+        - name: Check the updated {{ kind }} CR
+          kubernetes.core.k8s_info:
+            kind: "{{ kind }}"
+            api_version: '{{ api_version }}'
+            name: "{{ ansible_operator_meta.name }}"
+            namespace: '{{ ansible_operator_meta.namespace }}'
+          register: existing_deployment
 
     - name: Set previous_version version based on {{ deployment_type }} CR version status
       ansible.builtin.set_fact:
         previous_version: "{{ existing_deployment.resources[0].status.deployedVersion }}"
-      when:
-        - existing_deployment.resources | length > 0
-        - existing_deployment.resources[0].status.deployedVersion is defined
-
-- name: Check previous_version against gating_version if defined
-  block:
+      when: existing_deployment.resources[0].status.deployedVersion is defined
 
     - name: Set upgraded_from to previous_version ({{ previous_version }}) if older than gating_version ({{ gating_version }})
       ansible.builtin.set_fact:
@@ -25,5 +43,4 @@
       when:
         - previous_version is defined
         - previous_version is version(gating_version, '<')
-
-  when: gating_version | length
+...

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -12,10 +12,6 @@
     api_version: '{{ hostvars["localhost"]["inventory_file"].split("/")[4:6] | join("/")  }}'
     kind: '{{ hostvars["localhost"]["inventory_file"].split("/")[6]  }}'
 
-- name: Check for existing {{ deployment_type }} deployment
-  ansible.builtin.include_tasks: check_existing.yml
-  when: gating_version | length
-
 - name: Fail execution if image_pull_secret or image_pull_secrets are defined but as NoneType ('image_pull_secret[s]:')
   fail:
     msg: "If image_pull_secret or image_pull_secrets will not be used, their declarations should be removed."
@@ -61,6 +57,10 @@
     set_fact:
       web_url: "https://{{ route_host }}"
   when: ingress_type | lower == 'route'
+
+- name: Check for existing {{ deployment_type }} deployment
+  ansible.builtin.include_tasks: check_existing.yml
+  when: gating_version | length
 
 - name: Configure Postgres Configuration Secret
   include_tasks: postgres_configuration.yml


### PR DESCRIPTION
##### SUMMARY
If an existing deployment doesn't have the deployedVersion status set then we can force this to be set at the beginning of the operator execution.
This will help determine if there's an upgrade needed or not.
