### PR TITLE
Include postgres_configuration before check_existing tasks

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -59,12 +59,12 @@
       web_url: "https://{{ route_host }}"
   when: ingress_type | lower == 'route'
 
+- name: Configure Postgres Configuration Secret
+  include_tasks: postgres_configuration.yml
+
 - name: Check for existing {{ deployment_type }} deployment
   ansible.builtin.include_tasks: check_existing.yml
   when: gating_version | length
-
-- name: Configure Postgres Configuration Secret
-  include_tasks: postgres_configuration.yml
 
 - name: Set Bundle Certificate Authority
   include_tasks: set_bundle_cacert.yml


### PR DESCRIPTION
That way we set the postgres facts needed by combine_galaxy_settings, called by check_existing tasks.

Fixes https://issues.redhat.com/browse/AAP-33865
