### PR TITLE
Remove char in task name var preventing the variable from being evaluated

### DIFF
--- a/roles/common/tasks/check_existing.yml
+++ b/roles/common/tasks/check_existing.yml
@@ -23,7 +23,7 @@
             name: galaxy-status
             tasks_from: version.yml
 
-        - name: Check the updated {{ kind }} CR
+        - name: Check the updated {{ kind }} CR
           kubernetes.core.k8s_info:
             kind: "{{ kind }}"
             api_version: '{{ api_version }}'


### PR DESCRIPTION


##### SUMMARY
Remove char in task name var preventing the variable from being evaluated

Error:

```
 TASK [Set previous_version version based on {{ deployment_type }} CR version status] ******************************** 
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'existing_deployment.resources | length > 0' failed. The error was: error while evaluating conditional (existing_deployment.resources | length > 0): 'dict object' has no attribute 'resources'\n\nThe error appears to be in '/opt/ansible/roles/common/tasks/check_existing.yml': line 34
```
