### PR TITLE
Backup should specify the postgres_configuration parameter, not database.database_secret

### DIFF
--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Required: specify name of galaxy deployment to backup from
-deployment_name: ''
+# deployment_name: ''
 
 # Specify a pre-created PVC (name) to backup to
 backup_pvc: ''

--- a/roles/backup/tasks/custom_resource.yml
+++ b/roles/backup/tasks/custom_resource.yml
@@ -3,8 +3,7 @@
 - name: "Set {{ deployment_type }} object"
   set_fact:
     _galaxy: "{{ cr_spec }}"
-    _db_secret_value: |
-      {"database_secret": "{{ status['databaseConfigurationSecret'] }}"}
+    _db_secret_value: "{{ status['databaseConfigurationSecret'] }}"
     _admin_password_secret: "{{ status['adminPasswordSecret'] }}"
     _db_fields_encryption_secret: "{{ status['dbFieldsEncryptionSecret'] }}"
 
@@ -14,7 +13,7 @@
   with_items:
     - {"key": "db_fields_encryption_secret", "value": "{{ _db_fields_encryption_secret }}"}
     - {"key": "admin_password_secret", "value": "{{ _admin_password_secret }}"}
-    - {"key": "database", "value": "{{ _db_secret_value }}" }
+    - {"key": "postgres_configuration", "value": "{{ _db_secret_value }}" }
 
 - name: "Set {{ deployment_type }} object"
   set_fact:

--- a/roles/restore/tasks/init.yml
+++ b/roles/restore/tasks/init.yml
@@ -49,13 +49,12 @@
     - backup_name is defined
     - backup_name | length
 
-- name: Set deployment_name
+- name: Set deployment_name from restore.spec or default to backup status
   set_fact:
-    deployment_name: "{{ this_backup['resources'][0]['status']['deploymentName'] }}"
+    deployment_name: "{{ deployment_name | default(this_backup['resources'][0]['status']['deploymentName'], true) }}"
   when:
     - backup_name is defined
     - backup_name | length
-    - deployment_name is undefined
 
 - name: Set optional objectstorage backup fact
   set_fact:


### PR DESCRIPTION

##### SUMMARY
Backup should specify the postgres_configuration parameter, not database.database_secret

* database.database_secret is the new syntax that is currently used in eda-server-operator, but that has not yet been added to the galaxy CRD schema.

Without this change, the cr_object in the backup PVC looks like this:

```
      sh-4.4$ cat cr_object 
      spec:
        admin_password_secret: myaap-galaxy-admin-password
        database: {database_secret: myaap-galaxy-postgres-configuration}
        db_fields_encryption_secret: myaap-galaxy-db-fields-encryption
        file_storage_access_mode: ReadWriteMany
        file_storage_size: 10Gi
        file_storage_storage_class: nfs-local-rwx
        force_drop_db: false
        ingress_type: Route
        no_log: false
        postgres_configuration_secret: myaap-galaxy-postgres-configuration  # This should be database.database_secret instead
```

Note how there is a database.database_secret entry as well as a postgres_configuration_secret entry.

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
