### PR TITLE
Check spec_overrides when setting db_secret_name variable for restores

### DIFF
--- a/roles/restore/tasks/secrets.yml
+++ b/roles/restore/tasks/secrets.yml
@@ -27,18 +27,55 @@
   include_vars: "{{ tmp_secrets.path }}"
   no_log: "{{ no_log }}"
 
+
+# if spec_overrides is defined, use the postgres_configuration_secret from spec_overrides
+- block:
+    - name: Set db_secret_name to spec_overrides.postgres_configuration_secret
+      set_fact:
+        db_secret_name: "{{ spec_overrides.postgres_configuration_secret }}"
+
+    - name: Check for specified postgres_configuration_secret
+      kubernetes.core.k8s_info:
+        kind: Secret
+        namespace: '{{ ansible_operator_meta.namespace }}'
+        name: '{{ db_secret_name }}'
+      register: _db_secret_info
+      no_log: "{{ no_log }}"
+      when: db_secret_name | length
+
+    - name: Decode type from DB secret
+      set_fact:
+        db_secret_type: "{{ _db_secret_info.resources[0].data.type | b64decode }}"
+      no_log: "{{ no_log }}"
+      when: db_secret_name | length
+  when:
+    - spec_overrides is defined
+    - spec_overrides.postgres_configuration_secret is defined
+
+# If spec_overrides.postgres_configuration_secret is not set, use the backup secret
+- block:
+    - name: Decode type from databaseConfigurationSecret
+      set_fact:
+        db_secret_type: "{{ secrets['databaseConfigurationSecret']['data']['type'] | b64decode }}"
+      no_log: "{{ no_log }}"
+  when:
+    - spec_overrides is not defined
+    - spec_overrides.postgres_configuration_secret is not defined
+    - secrets['databaseConfigurationSecret'] is defined
+
 - name: If deployment is managed, set the new postgres_configuration_secret name
   block:
   - name: Set new postgres_configuration_secret name
     set_fact:
-      _generated_pg_secret_name: "{{ deployment_name }}-postgres-configuration"
       db_secret_name: "{{ deployment_name }}-postgres-configuration"
 
   - name: Override postgres_configuration_secret
     set_fact:
-      spec: "{{ spec | combine({'postgres_configuration_secret': _generated_pg_secret_name}, recursive=True) }}"
+      spec: "{{ spec | combine({'postgres_configuration_secret': db_secret_name}, recursive=True) }}"
     no_log: "{{ no_log }}"
-  when: secrets['databaseConfigurationSecret']['data']['type'] | b64decode == 'managed'
+  when:
+    - db_secret_type is defined
+    - db_secret_type == 'managed'
 
 - name: If deployment is managed, set the database_host in the pg config secret
   block:
@@ -55,7 +92,7 @@
     - name: Change postgres host and name value
       set_fact:
         _pg_data: "{{ _pg_secret['data'] | combine({'host': database_host | b64encode }) }}"
-        _pg_secret_name: "{{ deployment_name }}-postgres-configuration"
+        _pg_secret_name: "{{ db_secret_name }}"
       no_log: "{{ no_log }}"
 
     - name: Override postgres secret name
@@ -72,7 +109,9 @@
       set_fact:
         secrets: "{{ secrets | combine({'databaseConfigurationSecret': _pg_secret}) }}"
       no_log: "{{ no_log }}"
-  when: secrets['databaseConfigurationSecret']['data']['type'] | b64decode == 'managed'
+  when:
+    - db_secret_type is defined
+    - db_secret_type == 'managed'
 
 - name: Apply secret
   k8s:


### PR DESCRIPTION
##### SUMMARY

In the case where `spec_overrides.postgres_configuration_secret` is set on the GalaxyRestore object, we need to check it before setting the `db_secret_name` variable in the restore role or else the pg_restore step fails because it is pointed to the wrong db secret. 


