### PR TITLE
csv: Use PersistentVolumeClaim for file storage

### DIFF
--- a/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
@@ -577,7 +577,7 @@ spec:
         displayName: File storage
         path: storagePersistentVolumeClaim
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:io.kubernetes:PersistentVolumeClaim
       - description: Configuration secret for objectstorage
         displayName: Objectstorage secret
         path: storageSecret


### PR DESCRIPTION
##### SUMMARY
Rather than using the text field then we can use the kubernetes PersistentVolumeClaim descriptor so it resolves the associated object from the UI.

##### ADDITIONAL INFORMATION
Before
![csv_pvc_text_only](https://github.com/user-attachments/assets/28756d8a-861c-4d54-bc9f-c349f4bccaa3)

After
![csv_pvc_object](https://github.com/user-attachments/assets/18fb8186-e94c-40ec-9812-6425f2b1519d)