### PR TITLE
Add trailing slash to Galaxy API redirect link

### DIFF
--- a/roles/galaxy-api/templates/redirect-page.configmap.html.j2
+++ b/roles/galaxy-api/templates/redirect-page.configmap.html.j2
@@ -67,7 +67,7 @@ data:
         <p class="doc-note">
             The API endpoints for this platform service will temporarily remain available at the URL for this service.
             Please use the Ansible Automation Platform API endpoints corresponding to this component in the future.
-            These can be found at <a href="{{ public_base_url }}/{{ pulp_combined_settings.galaxy_api_path_prefix }}" target="_blank">{{ public_base_url }}/{{ pulp_combined_settings.galaxy_api_path_prefix }}</a>.
+            These can be found at <a href="{{ public_base_url }}/{{ pulp_combined_settings.galaxy_api_path_prefix }}/" target="_blank">{{ public_base_url }}/{{ pulp_combined_settings.galaxy_api_path_prefix }}/</a>.
         </p>
 
         <!-- Include any additional scripts if needed -->


### PR DESCRIPTION

##### SUMMARY
- without this trailing slash, user will currently see a 404


For example, https://galaxy-host.openshift.com/api/galaxy will not resolve, but https://galaxy-host.openshift.com/api/galaxy/ will.

##### ADDITIONAL INFORMATION

We should also fix the nginx.conf long-term so that it works without the slash too.