### PR TITLE
galaxy operator: reduce resource limit

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -42,7 +42,7 @@ spec:
         - --leader-elect
         - --leader-election-id=galaxy-operator
         image: controller:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: galaxy-operator
         env:
           # Watch one namespace (namespace-scoped).

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -42,7 +42,7 @@ spec:
         - --leader-elect
         - --leader-election-id=galaxy-operator
         image: controller:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: galaxy-operator
         env:
           # Watch one namespace (namespace-scoped).
@@ -83,7 +83,7 @@ spec:
         resources:
           limits:
             cpu: 2000m
-            memory: 4000Mi
+            memory: 1800Mi
           requests:
             cpu: 10m
             memory: 256Mi


### PR DESCRIPTION
##### SUMMARY
Closes https://issues.redhat.com/browse/AAP-37931
Reducing the galaxy operator's resource limit to the best minimum value that doesn't makes the operator OOMkilled.
