### PR TITLE
Remove x-kubernetes-preserve-unknown-fields field from schema so explain params work

### DIFF
--- a/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
@@ -20,7 +20,6 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
-        x-kubernetes-preserve-unknown-fields: true
         description: Schema validation for the Galaxy CRD
         properties:
           apiVersion:

--- a/config/crd/bases/galaxy_v1beta1_galaxybackup_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxybackup_crd.yaml
@@ -20,7 +20,6 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
           description: Schema validation for the GalaxyBackup CRD
           properties:
             spec:

--- a/config/crd/bases/galaxy_v1beta1_galaxyrestore_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxyrestore_crd.yaml
@@ -20,7 +20,6 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
-          x-kubernetes-preserve-unknown-fields: true
           description: Schema validation for the GalaxyRestore CRD
           properties:
             spec:


### PR DESCRIPTION

##### SUMMARY
Remove x-kubernetes-preserve-unknown-fields field from schema so that users can run:

```
oc explain Galaxy.spec
```


When I remove this line under Galaxy.spec in the CRD, the oc explain works:

```
x-kubernetes-preserve-unknown-fields: true
```

When this line is removed, or set to false (default), then parameters that are not explicitly defined on the CRD schema will not be accepted and the k8s validator will automatically (and silently) omit any parameters that it does not know about when the CRD is modified / created.



##### ADDITIONAL INFORMATION

In the case of Galaxy, I think that should be fine because all accepted params are defined in the CRD schema already.

The `spec.extra_settings` param will still set that preserve-unknown-fields config to true for just extra_settings, so that's OK.
