### PR TITLE
Remove namespace on dev Custom Resource

### DIFF
--- a/dev/galaxy.cr.yml
+++ b/dev/galaxy.cr.yml
@@ -3,7 +3,6 @@ apiVersion: galaxy.ansible.com/v1beta1
 kind: Galaxy
 metadata:
   name: galaxy
-  namespace: galaxy
 spec:
   
   # ingress_type: nodeport

--- a/galaxy-cr.yaml
+++ b/galaxy-cr.yaml
@@ -3,7 +3,6 @@ apiVersion: galaxy.ansible.com/v1beta1
 kind: Galaxy
 metadata:
   name: galaxy
-  namespace: galaxy
 spec:
   hostname: localhost
   ingress_type: ingress


### PR DESCRIPTION
##### SUMMARY

The ansible_up.sh script uses the NAMESPACE environment variable to create resources but the dev CR hardcodes galaxy as namespace value. So when using a different value than NAMESPACE=galaxy for that script then the operator fails because the signing script and secret (and probably other resources) are created into a different namespace than the operator.

##### ADDITIONAL INFORMATION

```console
TASK [Set environment variable for the GPG key ID] ********************************
fatal: [localhost]: FAILED! => {"msg": "The input for the community.crypto.gpg_fingerprint filter must be a string; got <class 'ansible.template.AnsibleUndefined'> instead"}

```