### PR TITLE
Remove default namespace from CR examples so current context is used

### DIFF
--- a/config/samples/galaxy_v1beta1_galaxy_cr.unauthenticated-demo.yaml
+++ b/config/samples/galaxy_v1beta1_galaxy_cr.unauthenticated-demo.yaml
@@ -3,7 +3,6 @@ apiVersion: galaxy.ansible.com/v1beta1
 kind: Galaxy
 metadata:
   name: galaxy
-  namespace: galaxy
 spec:
   hostname: galaxy.local
   ingress_type: ingress

--- a/dev/galaxy.cr.yml
+++ b/dev/galaxy.cr.yml
@@ -3,7 +3,6 @@ apiVersion: galaxy.ansible.com/v1beta1
 kind: Galaxy
 metadata:
   name: galaxy
-  namespace: galaxy
 spec:
   
   # ingress_type: nodeport

--- a/galaxy-cr.yaml
+++ b/galaxy-cr.yaml
@@ -3,7 +3,6 @@ apiVersion: galaxy.ansible.com/v1beta1
 kind: Galaxy
 metadata:
   name: galaxy
-  namespace: galaxy
 spec:
   hostname: localhost
   ingress_type: ingress


### PR DESCRIPTION
##### SUMMARY
Remove default namespace from CR examples so current context is used

If someone specifies a namespace different from `galaxy`, it will not fully work. This is because there were a couple places where the galaxy namespace was hardcoded.  This change will fix that.

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
