### PR TITLE
Switch context to namespace provided in ansible-up.sh

### DIFF
--- a/ansible-up.sh
+++ b/ansible-up.sh
@@ -78,6 +78,7 @@ fi
 # -- Create namespace
 # oc new-project $NAMESPACE
 kubectl create namespace $NAMESPACE
+kubectl config set-context --current --namespace=$NAMESPACE
 
 # -- Delete old operator deployment
 kubectl delete deployment galaxy-operator-controller-manager


### PR DESCRIPTION
##### SUMMARY

Switch context to namespace provided in ansible-up.sh so that it is used when creating the galaxy CR later on in the up.sh script.
