### PR TITLE
AAP-20309 conditional redis pvc

### DIFF
--- a/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
@@ -277,6 +277,9 @@ spec:
               tolerations:
                 description: node tolerations for the Galaxy pods
                 type: string
+              redis_data_persistence:
+                description: Specify whether or not to have a redis pvc
+                type: boolean
               postgres_selector:
                 description: nodeSelector for the Postgres pods
                 type: string

--- a/dev/galaxy.cr.yml
+++ b/dev/galaxy.cr.yml
@@ -33,6 +33,9 @@ spec:
   # # We have a little over 10GB free on GHA VMs/instances
   file_storage_size: "10Gi"
   file_storage_storage_class: nfs-local-rwx
+
+  # set redis_data_persistence to true in case you need a redis pvc
+  redis_data_persistence: false
   
   pulp_settings:
     api_root: "/api/galaxy/pulp/"

--- a/dev/galaxy.cr.yml
+++ b/dev/galaxy.cr.yml
@@ -35,7 +35,7 @@ spec:
   file_storage_storage_class: nfs-local-rwx
 
   # set redis_data_persistence to true in case you need a redis pvc
-  redis_data_persistence: false
+  # redis_data_persistence: false
   
   pulp_settings:
     api_root: "/api/galaxy/pulp/"

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -5,3 +5,4 @@ redis_storage_size: 1Gi
 # Here we use  _galaxy_ansible_com_galaxy to get un-modified cr
 # see: https://github.com/operator-framework/operator-sdk/issues/1770
 raw_spec: "{{ vars['_galaxy_ansible_com_galaxy']['spec'] }}"
+redis_data_persistence: true

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -5,6 +5,7 @@
     definition: "{{ lookup('template', 'templates/' + item + '.pvc.yaml.j2') | from_yaml }}"
   with_items:
     - redis
+  when: redis_data_persistence is true
 
 - name: redis service
   k8s:

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -98,5 +98,9 @@ spec:
 {% endif %}
       volumes:
         - name: '{{ ansible_operator_meta.name }}-redis-data'
+{% if redis_data_persistence %}
           persistentVolumeClaim:
             claimName: '{{ ansible_operator_meta.name }}-redis-data'
+{% else %}
+          emptyDir: {}
+{% endif %}


### PR DESCRIPTION
##### SUMMARY
Closes: https://issues.redhat.com/browse/AAP-20309
Set condition on redis pvc.

This PR makes it possible to reduce the number of PVC's required to deploy Galaxy by making redis data persistence optional. 

To do so, modify your Galaxy spec to add is param:
```
spec:
  redis_data_persistence: false
```

It is still recommended to set this to true, and having it backed by a PVC should make scaling up and down pods a bit smoother.  But the redis cache should be recreated if the redis pod should go down, so this is acceptable for demo/test environments.
