### PR TITLE
Fix redis_data_persistence conditional

### DIFF
--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -5,7 +5,7 @@
     definition: "{{ lookup('template', 'templates/' + item + '.pvc.yaml.j2') | from_yaml }}"
   with_items:
     - redis
-  when: redis_data_persistence is true
+  when: redis_data_persistence | bool
 
 - name: redis service
   k8s:

--- a/roles/redis/templates/redis.deployment.yaml.j2
+++ b/roles/redis/templates/redis.deployment.yaml.j2
@@ -98,7 +98,7 @@ spec:
 {% endif %}
       volumes:
         - name: '{{ ansible_operator_meta.name }}-redis-data'
-{% if redis_data_persistence %}
+{% if redis_data_persistence | bool %}
           persistentVolumeClaim:
             claimName: '{{ ansible_operator_meta.name }}-redis-data'
 {% else %}


### PR DESCRIPTION
##### SUMMARY

Fixes error:

```
`task path: /opt/ansible/roles/redis/tasks/main.yml:2\u001b[0m\n\u001b[0;31mfatal: [localhost]: FAILED! => {\"msg\": \"The conditional check 'redis_data_persistence is true' failed. The error was: template error while templating string: no test named 'true'. String: {% if redis_data_persistence is true %} True {% else %} False {% endif %}\\n\\nThe error appears to be in '/opt/ansible/roles/redis/tasks/main.yml'`
```

##### ADDITIONAL INFORMATION

Before this change, fresh installs were failing.