### PR TITLE
Feature: Add ability to idle Galaxy deployments and statefulsets

### DIFF
--- a/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
@@ -154,6 +154,9 @@ spec:
                 default: false
                 description: (Deprecated) Force drop the database of the new Galaxy before restoring. USE WITH CAUTION!
                 type: boolean
+              idle_deployment:
+                description: Scale down deployments to put Galaxy into an idle state
+                type: boolean
               no_log:
                 default: true
                 description: Configure no_log for no_log tasks

--- a/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
@@ -543,6 +543,13 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
+      - description: Scale down deployments to put Galaxy into an idle state
+        displayName: Idle Deployment
+        path: idle_deployment
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: No Log Configuration
         path: no_log
         x-descriptors:

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -9,6 +9,9 @@ is_openshift: false
 
 deployment_type: galaxy
 
+# idle_deployment - Scale down replicas to put Galaxy into an idle mode
+idle_deployment: false
+
 api: {}
 _api:
   replicas: 1

--- a/roles/common/tasks/idle_deployment.yml
+++ b/roles/common/tasks/idle_deployment.yml
@@ -1,0 +1,35 @@
+---
+
+- name: Scale down {{ deployment_type }} deployments
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: "{{ ansible_operator_meta.name }}-{{ item }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
+      spec:
+        replicas: 0
+  loop:
+    - api
+    - content
+    - web
+    - worker
+    - redis
+
+- name: Scale down PostgreSQL Statefulset
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: "{{ ansible_operator_meta.name }}-postgres-{{ supported_pg_version }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
+      spec:
+        replicas: 0
+  when: managed_database | bool
+
+- name: End Playbook
+  ansible.builtin.meta: end_play

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -62,6 +62,10 @@
 - name: Configure Postgres Configuration Secret
   include_tasks: postgres_configuration.yml
 
+- name: Idle {{ deployment_type }}
+  ansible.builtin.include_tasks: idle_deployment.yml
+  when: idle_deployment | bool
+
 - name: Check for existing {{ deployment_type }} deployment
   ansible.builtin.include_tasks: check_existing.yml
   when: gating_version | length

--- a/roles/common/tasks/postgres_configuration.yml
+++ b/roles/common/tasks/postgres_configuration.yml
@@ -91,6 +91,10 @@
   set_fact:
     postgres_configuration_secret_name: "{{ pg_config['resources'][0]['metadata']['name'] }}"
 
+- name: Set database as managed
+  set_fact:
+    managed_database: "{{ pg_config['resources'][0]['data']['type'] | default('') | b64decode == 'managed' }}"
+
 - name: Get postgres configuration secret
   k8s_info:
     kind: Secret

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -22,10 +22,6 @@
     custom_resource: "{{ hostvars[inventory_hostname][custom_resource_key] }}"
     custom_resource_status: "{{ hostvars[inventory_hostname][custom_resource_key]['status'] | default({}) }}"
 
-- name: Set database as managed
-  set_fact:
-    managed_database: "{{ pg_config['resources'][0]['data']['type'] | default('') | b64decode == 'managed' }}"
-
 - name: Set postgres label if not defined by user
   set_fact:
     postgres_label_selector: "app.kubernetes.io/instance=postgres-{{ ansible_operator_meta.name }}"


### PR DESCRIPTION
##### SUMMARY
This PR adds the ability to scale down your Galaxy Deployments StatefulSets and subsequently your pods to save on resource utilization if you have scheduled downtime.  

This can also be useful for scaling down the pods when upgrading the PostgreSQL database when you have an external database configured.  This way you won't have requests hitting the database during scheduled maintenance when the DB is being upgraded.

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
---
apiVersion: galaxy.ansible.com/v1beta1
kind: Galaxy
metadata:
  name: galaxy
spec:
  idle_deployment: false   # set to true to scale down all pods
```
