### PR TITLE
fix incorrect format of dict with set_fact

### DIFF
--- a/roles/common/tasks/azure-storage-configuration.yml
+++ b/roles/common/tasks/azure-storage-configuration.yml
@@ -118,7 +118,8 @@
 
 - name: Add azure connection string to azure settings
   set_fact:
-    azure_connection_string_dict: "{'AZURE_CONNECTION_STRING': '{{ _custom_azure_configuration['resources'][0]['data']['azure-connection-string'] | b64decode }}' }"
+    azure_connection_string_dict:
+      AZURE_CONNECTION_STRING: "{{ _custom_azure_configuration['resources'][0]['data']['azure-connection-string'] | b64decode }}"
   no_log: "{{ no_log }}"
   when:
     - azure_secret_data_avaiable
@@ -127,20 +128,24 @@
 
 - name: Add azure account name azure settings
   set_fact:
-    azure_account_name_dict : "{'AZURE_ACCOUNT_NAME': '{{ azure_account_name }}' }"
+    azure_account_name_dict:
+      AZURE_ACCOUNT_NAME: "{{ azure_account_name }}"
 
 - name: Add azure account key azure settings
   set_fact:
-    azure_account_key_dict : "{'AZURE_ACCOUNT_KEY': '{{ azure_account_key }}' }"
+    azure_account_key_dict:
+      AZURE_ACCOUNT_KEY: "{{ azure_account_key }}"
   no_log: "{{ no_log }}"
 
 - name: Add azure container azure settings
   set_fact:
-    azure_container_dict : "{'AZURE_CONTAINER': '{{ azure_container }}' }"
+    azure_container_dict:
+      AZURE_CONTAINER: "{{ azure_container }}"
 
 - name: Add azure container path azure settings
   set_fact:
-    azure_container_path_dict : "{'AZURE_LOCATION': '{{ object_storage_path }}' }"
+    azure_container_path_dict:
+      AZURE_LOCATION: "{{ object_storage_path }}"
 
 - name: merge azure_account_name with settings
   set_fact:

--- a/roles/common/tasks/s3-storage-configuration.yml
+++ b/roles/common/tasks/s3-storage-configuration.yml
@@ -151,30 +151,36 @@
 
 - name: Add s3 access key id to s3 settings
   set_fact:
-    s3_access_key_id_dict : "{'AWS_ACCESS_KEY_ID': '{{ s3_access_key_id }}' }"
+    s3_access_key_id_dict:
+      AWS_ACCESS_KEY_ID: "{{ s3_access_key_id }}"
   no_log: "{{ no_log }}"
 
 - name: Add s3 secret key to s3 settings
   set_fact:
-    s3_secret_access_key_dict : "{'AWS_SECRET_ACCESS_KEY': '{{ s3_secret_access_key }}' }"
+    s3_secret_access_key_dict:
+      AWS_SECRET_ACCESS_KEY: "{{ s3_secret_access_key }}"
   no_log: "{{ no_log }}"
 
 - name: Add s3 bucket to s3 settings
   set_fact:
-    s3_bucket_name_dict : "{'AWS_STORAGE_BUCKET_NAME': '{{ s3_bucket_name }}' }"
+    s3_bucket_name_dict:
+      AWS_STORAGE_BUCKET_NAME: "{{ s3_bucket_name }}"
 
 - name: Add s3 bucket path to s3 settings
   set_fact:
-    s3_bucket_path_dict : "{'MEDIA_ROOT': '{{ object_storage_path }}' }"
+    s3_bucket_path_dict:
+      MEDIA_ROOT: "{{ object_storage_path }}"
 
 - name: Add s3 region to s3 settings
   set_fact:
-    s3_region_dict : "{'AWS_S3_REGION_NAME': '{{ s3_region }}' }"
+    s3_region_dict:
+      AWS_S3_REGION_NAME: "{{ s3_region }}"
   when: s3_region is defined
 
 - name: Add s3 endpoint to s3 settings
   set_fact:
-    s3_endpoint_dict : "{'AWS_S3_ENDPOINT_URL': '{{ s3_endpoint }}' }"
+    s3_endpoint_dict:
+      AWS_S3_ENDPOINT_URL: "{{ s3_endpoint }}"
   when: s3_endpoint is defined
 
 - name: merge s3_access_key_id with settings


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Private Automation Hub installation with S3 failing with following error
```
2025-02-28T02:11:09.543211999Z  TASK [merge s3_access_key_id with settings] ******************************** 
2025-02-28T02:11:09.543211999Z ESC[0;31mfatal: [localhost]: FAILED! => {"msg": "|combine expects dictionaries, got \"{'AWS_ACCESS_KEY_ID': '**************\\n' }\""}ESC[0m
```
Reason for this problem is incorrect way of setting a variable fact as `string` https://github.com/ansible/galaxy-operator/blob/main/roles/common/tasks/s3-storage-configuration.yml#L152-L155 which per the playbook should be a `dictionary` because `combine` filter works on dictionaries https://github.com/ansible/galaxy-operator/blob/main/roles/common/tasks/s3-storage-configuration.yml#L180-L183

This problem is same for azure storage as well.

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
