### PR TITLE
change client_max_body_size var type to integer

### DIFF
--- a/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
@@ -230,9 +230,9 @@ spec:
                 description: Secret where the ingress TLS secret can be found
                 type: string
               nginx_client_max_body_size:
-                description: NGINX client max body size
-                default: 10m
-                type: string
+                description: Sets the maximum allowed size of the client request body in megabytes (defaults to 10M)
+                default: 10
+                type: integer
               nginx_proxy_read_timeout:
                 description: NGINX proxy read timeout
                 default: 120s

--- a/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
@@ -214,10 +214,12 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:ingress_type:LoadBalancer
-      - displayName: Nginx client max body size
+      - displayName: Set the maximum allowed size of the client request body in megabytes
+          for nginx
         path: nginx_client_max_body_size
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:number
       - displayName: Nginx proxy read timeout
         path: nginx_proxy_read_timeout
         x-descriptors:

--- a/roles/galaxy-route/defaults/main.yml
+++ b/roles/galaxy-route/defaults/main.yml
@@ -8,7 +8,7 @@ hostname: '{{ deployment_type }}.example.com'
 
 
 # https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
-nginx_client_max_body_size: 10m
+nginx_client_max_body_size: 10
 
 nginx_proxy_read_timeout: 120s
 nginx_proxy_connect_timeout: 120s
@@ -23,8 +23,8 @@ haproxy_timeout: 180s
 #   kubernetes.io/ingress.class: nginx
 #   nginx.ingress.kubernetes.io/proxy-connect-timeout: 60s
 ingress_annotations: |
-  nginx.ingress.kubernetes.io/proxy-body-size: {{ nginx_client_max_body_size }}
-  nginx.org/client-max-body-size: {{ nginx_client_max_body_size }}
+  nginx.ingress.kubernetes.io/proxy-body-size: {{ nginx_client_max_body_size }}M
+  nginx.org/client-max-body-size: {{ nginx_client_max_body_size }}M
   nginx.ingress.kubernetes.io/proxy-read-timeout: {{ nginx_proxy_read_timeout }}
   nginx.ingress.kubernetes.io/proxy-connect-timeout: {{ nginx_proxy_connect_timeout }}
   nginx.ingress.kubernetes.io/proxy-send-timeout: {{ nginx_proxy_send_timeout }}

--- a/roles/galaxy-web/README.md
+++ b/roles/galaxy-web/README.md
@@ -15,7 +15,7 @@ Role Variables
     * `replicas`: Number of pod replicas.
 * `image_web`: The image name. Default: quay.io/ansible/galaxy-ui
 * `image_web_version`: The image tag. Default: main
-* `nginx_client_max_body_size`: Sets the maximum allowed size of the client request body.
+* [client_max_body_size](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) with `nginx_client_max_body_size` (default of 10M)
 
 Requirements
 ------------

--- a/roles/galaxy-web/defaults/main.yml
+++ b/roles/galaxy-web/defaults/main.yml
@@ -30,3 +30,5 @@ galaxy_nginx_conf_dir: "/etc/nginx/default.d"
 # Here we use  _galaxy_ansible_com_galaxy to get un-modified cr
 # see: https://github.com/operator-framework/operator-sdk/issues/1770
 raw_spec: "{{ vars['_galaxy_ansible_com_galaxy']['spec'] }}"
+
+nginx_client_max_body_size: 10

--- a/roles/galaxy-web/templates/galaxy-web.configmap.yaml.j2
+++ b/roles/galaxy-web/templates/galaxy-web.configmap.yaml.j2
@@ -48,7 +48,7 @@ data:
             proxy_connect_timeout {{ nginx_proxy_connect_timeout }};
             proxy_send_timeout {{ nginx_proxy_send_timeout }};
 
-            client_max_body_size {{ nginx_client_max_body_size }};
+            client_max_body_size {{ nginx_client_max_body_size }}M;
 
             # Redirect all HTTP links to the matching HTTPS page
             return 301 https://$host$request_uri;
@@ -85,7 +85,7 @@ data:
 
             # The default client_max_body_size is 1m. Clients uploading
             # files larger than this will need to chunk said files.
-            client_max_body_size {{ nginx_client_max_body_size }};
+            client_max_body_size {{ nginx_client_max_body_size }}M;
 
             # Gunicorn docs suggest this value.
             keepalive_timeout 5;


### PR DESCRIPTION
##### SUMMARY
This PR try to make it more consistent with the type we use in the awx-operator and to prevent input user errors due to the possibility of entering any value when defining it in the CR, as the variable allows the string type.

##### ADDITIONAL INFORMATION
This change was also applied to the `awx-operator` repository, and during a discussion in the PR submitted to that repository, we concluded that it might be interesting to apply the same change here in the `galaxy-operator`.

https://github.com/ansible/galaxy-operator/issues/182
https://github.com/ansible/awx-operator/pull/2014
