### PR TITLE
setting default cluster_name to cluster.local to make restores work with defaults on most clusters

### DIFF
--- a/roles/restore/defaults/main.yml
+++ b/roles/restore/defaults/main.yml
@@ -18,7 +18,7 @@ db_fields_encryption_secret: ''
 sso_secret: ''
 
 # Default cluster name
-cluster_name: '' # On most clusters, this is 'cluster.local'
+cluster_name: 'cluster.local' # On most clusters, this is 'cluster.local'
 
 # Default resource requirements
 restore_resource_requirements:


### PR DESCRIPTION
##### SUMMARY
setting default cluster_name to cluster.local to make restores work with defaults on most clusters
