### PR TITLE
Fixing restores to use the correct postgres config

### DIFF
--- a/roles/restore/defaults/main.yml
+++ b/roles/restore/defaults/main.yml
@@ -18,7 +18,7 @@ db_fields_encryption_secret: ''
 sso_secret: ''
 
 # Default cluster name
-cluster_name: 'cluster.local' # On most clusters, this is 'cluster.local'
+cluster_name: '' # On most clusters, this is 'cluster.local'
 
 # Default resource requirements
 restore_resource_requirements:

--- a/roles/restore/defaults/main.yml
+++ b/roles/restore/defaults/main.yml
@@ -18,7 +18,7 @@ db_fields_encryption_secret: ''
 sso_secret: ''
 
 # Default cluster name
-cluster_name: '' # On most clusters, this is 'cluster.local'
+cluster_name: 'cluster.local' # On most clusters, this is 'cluster.local'
 
 # Default resource requirements
 restore_resource_requirements:

--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -1,27 +1,14 @@
 ---
-- name: Check for specified PostgreSQL configuration
+- name: Get PostgreSQL configuration
   k8s_info:
     kind: Secret
     namespace: '{{ ansible_operator_meta.namespace }}'
     name: '{{ db_secret_name }}'
-  register: _custom_pg_config_resources
+  register: pg_config
   no_log: "{{ no_log }}"
-  when:
-    - db_secret_name is defined
-    - db_secret_name | length
-
-- name: Check for default PostgreSQL configuration
-  k8s_info:
-    kind: Secret
-    namespace: '{{ ansible_operator_meta.namespace }}'
-    name: '{{ deployment_name }}-postgres-configuration'
-  register: _default_pg_config_resources
-  no_log: "{{ no_log }}"
-
-- name: Set PostgreSQL configuration
-  set_fact:
-    pg_config: '{{ _custom_pg_config_resources["resources"] | default([]) | length | ternary(_custom_pg_config_resources, _default_pg_config_resources) }}'
-  no_log: "{{ no_log }}"
+  until: pg_config['resources'] | length
+  delay: 10
+  retries: 60
 
 - name: Store Database Configuration
   set_fact:
@@ -96,6 +83,14 @@
     resolvable_db_host: '{{ (postgres_type == "managed") | ternary(postgres_host + "." + ansible_operator_meta.namespace + ".svc" + _cluster_name, postgres_host) }}'  # yamllint disable-line rule:line-length
   no_log: "{{ no_log }}"
 
+- name: Set pg_isready command
+  ansible.builtin.set_fact:
+    pg_isready: >-
+      pg_isready 
+      -h {{ resolvable_db_host }} 
+      -p {{ postgres_port }}
+  no_log: "{{ no_log }}"
+
 - name: Set pg_restore command
   set_fact:
     pg_restore: >-
@@ -149,6 +144,11 @@
         exit $rc
       }
       keepalive_file=\"$(mktemp)\"
+      until {{ pg_isready }} &> /dev/null
+      do
+          echo \"Waiting until Postgres is accepting connections...\"
+          sleep 2
+      done
       while [[ -f \"$keepalive_file\" ]]; do
         echo 'Migrating data from old database...'
         sleep 60


### PR DESCRIPTION
##### SUMMARY

Restores are currently obtaining the previous deployment's postgres config name resulting in failed restores.

This fixes restores to use the correct postgres config.