### PR TITLE
add support for ldap bind password using secrets

### DIFF
--- a/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
@@ -72,6 +72,9 @@ spec:
                         type: boolean
                     type: object
                 type: object
+              ldap_bind_password_secret:
+                description: Secret where the bind password of the ldap configuration is stored
+                type: string
               bundle_cacert_secret:
                 description: Secret where the trusted Certificate Authority Bundle is stored
                 type: string

--- a/docs/user-guide/ldap_configuration.md
+++ b/docs/user-guide/ldap_configuration.md
@@ -1,0 +1,25 @@
+## LDAP configuration
+
+LDAP can be configured by adding pulp settings as specified in [the documentation](https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/integration/ldap.html).
+The bind password () can be masked by storing the password in a secret. You need to specify the ```ldap_bind_password_secret``` in the spec:
+
+```yaml
+---
+spec:
+  ...
+  ldap_bind_password_secret: <name-of-your-secret>
+```
+
+The secret should be formatted as follows:
+
+```yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <name-of-your-secret>
+  namespace: <target-namespace>
+type: Opaque
+stringData:
+  password: <bind-user-password>
+```

--- a/roles/galaxy-config/tasks/combine_galaxy_settings.yml
+++ b/roles/galaxy-config/tasks/combine_galaxy_settings.yml
@@ -74,3 +74,35 @@
     pulp_combined_settings: "{{ default_settings|combine(raw_pulp_settings, recursive=True) if pulp_settings is defined and pulp_settings is not none else default_settings }}"
     cacheable: yes
   no_log: "{{ no_log }}"
+
+- name: add PULP_AUTH_LDAP_BIND_PASSWORD to pulp settings if ldap_bind_password_secret is defined
+  block:
+  - name: Check for specified ldap configuration secret
+    k8s_info:
+      kind: Secret
+      namespace: '{{ ansible_operator_meta.namespace }}'
+      name: '{{ ldap_bind_password_secret }}'
+    register: _ldap_configuration
+    no_log: "{{ no_log }}"
+    when: ldap_bind_password_secret | length
+
+  - name: Assert that the specified ldap configuration secret exists
+    assert:
+      that:
+        - _ldap_configuration['resources'] | default([]) | length
+      fail_msg: "The specified secret '{{ ldap_bind_password_secret }}' does not exist."
+    no_log: "{{ no_log }}"
+    when: ldap_bind_password_secret | length
+
+  - name: set ldap secret
+    set_fact:
+      ldap_password:
+        PULP_AUTH_LDAP_BIND_PASSWORD:  "{{ _ldap_configuration['resources'][0]['data']['password'] | b64decode }}"
+    no_log: "{{ no_log }}"
+
+  - name: add ldap bind password to combined settings
+    set_fact:
+      pulp_combined_settings: "{{ pulp_combined_settings|combine(ldap_password, recursive=True) }}"
+    no_log: "{{ no_log }}"
+    when: ldap_bind_password_secret | length
+  when: ldap_bind_password_secret is defined


### PR DESCRIPTION
##### SUMMARY
Currently the LDAP configuration can not be configured without specifying the pulp setting PULP_AUTH_LDAP_BIND_PASSWORD in plain text. This is a small update to allow support for secrets when configuring PULP_AUTH_LDAP_BIND_PASSWORD 

##### ADDITIONAL INFORMATION
/etc/pulp/settings after.
```
bash-4.4$ cat /etc/pulp/settings.py
GALAXY_API_PATH_PREFIX = "api/galaxy"
CACHE_ENABLED = True
DB_ENCRYPTION_KEY = "/etc/pulp/keys/database_fields.symmetric.key"
.....
PUBLIC_KEY_PATH = "/etc/pulp/keys/container_auth_public_key.pem"
PRIVATE_KEY_PATH = "/etc/pulp/keys/container_auth_private_key.pem"
CSRF_TRUSTED_ORIGINS = ["http://localhost", "https://localhost"]
PULP_AUTH_LDAP_BIND_PASSWORD = "yourpassword"
```
without specifying "ldap_bind_password_secret", PULP_AUTH_LDAP_BIND_PASSWORD is absent