### PR TITLE
Adding validation policies

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
+- ../policies
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 

--- a/config/policies/kustomization.yaml
+++ b/config/policies/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- storage_type_binding.yaml
+- storage_type_validation.yaml

--- a/config/policies/storage_type_binding.yaml
+++ b/config/policies/storage_type_binding.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "storage-type-binding"
+spec:
+  policyName: "galaxy-operator-storage-type-validation"
+  validationActions: [Deny]

--- a/config/policies/storage_type_validation.yaml
+++ b/config/policies/storage_type_validation.yaml
@@ -1,0 +1,25 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "storage-type-validation"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["galaxy.ansible.com"]
+      apiVersions: ["*"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["galaxies"]
+  validations:
+  - expression: "has(object.spec.storage_type)"
+    message: "storage_type should not be empty"
+    reason: Invalid
+  - expression: "!(object.spec.storage_type in ['File', 'file'] && !has(object.spec.file_storage_storage_class))"
+    message: "please specify a rwx file_storage_storage_class"
+    reason: Invalid
+  - expression: "!(object.spec.storage_type in ['S3', 's3'] && !has(object.spec.object_storage_s3_secret))"
+    message: "object_storage_s3_secret should not be empty"
+    reason: Invalid
+  - expression: "!(object.spec.storage_type in ['Azure', 'azure'] && !has(object.spec.object_storage_azure_secret))"
+    message: "object_storage_azure_secret should not be empty"
+    reason: Invalid

--- a/config/samples/galaxy_v1beta1_galaxy_cr.ci.yaml
+++ b/config/samples/galaxy_v1beta1_galaxy_cr.ci.yaml
@@ -11,6 +11,7 @@ spec:
   file_storage_access_mode: "ReadWriteMany"
   # We have a little over 10GB free on GHA VMs/instances
   file_storage_size: "10Gi"
+  file_storage_storage_class: standard
   container_token_secret: "container-auth"
   pulp_settings:
     allowed_export_paths:

--- a/config/samples/galaxy_v1beta1_galaxy_cr.galaxy-demo.yaml
+++ b/config/samples/galaxy_v1beta1_galaxy_cr.galaxy-demo.yaml
@@ -10,6 +10,7 @@ spec:
   file_storage_access_mode: "ReadWriteMany"
   # The minikube VM won't go any larger.
   file_storage_size: "375Gi"
+  file_storage_storage_class: standard
   # Default images:
   image: quay.io/ansible/galaxy-ng
   image_version: latest

--- a/config/samples/galaxy_v1beta1_galaxy_cr.galaxy.ci.yaml
+++ b/config/samples/galaxy_v1beta1_galaxy_cr.galaxy.ci.yaml
@@ -17,6 +17,7 @@ spec:
   file_storage_access_mode: "ReadWriteMany"
   # We have a little over 10GB free on GHA VMs/instances
   file_storage_size: "10Gi"
+  file_storage_storage_class: standard
   pulp_settings:
     allowed_export_paths:
       - /tmp

--- a/config/samples/galaxy_v1beta1_galaxy_cr.galaxy.externaldb.ci.yaml
+++ b/config/samples/galaxy_v1beta1_galaxy_cr.galaxy.externaldb.ci.yaml
@@ -18,6 +18,7 @@ spec:
   file_storage_access_mode: "ReadWriteMany"
   # We have a little over 10GB free on GHA VMs/instances
   file_storage_size: "10Gi"
+  file_storage_storage_class: standard
   pulp_settings:
     allowed_export_paths:
       - /tmp

--- a/config/samples/galaxy_v1beta1_galaxy_cr.galaxy.s6.ci.yaml
+++ b/config/samples/galaxy_v1beta1_galaxy_cr.galaxy.s6.ci.yaml
@@ -15,6 +15,7 @@ spec:
   ingress_type: nodeport
   # k3s local-path requires this
   file_storage_access_mode: "ReadWriteMany"
+  file_storage_storage_class: standard
   # We have a little over 10GB free on GHA VMs/instances
   file_storage_size: "10Gi"
   pulp_settings:

--- a/config/samples/galaxy_v1beta1_galaxy_cr.molecule.ci.yaml
+++ b/config/samples/galaxy_v1beta1_galaxy_cr.molecule.ci.yaml
@@ -10,6 +10,7 @@ spec:
   ingress_type: nodeport
   # k3s local-path requires this
   file_storage_access_mode: "ReadWriteOnce"
+  file_storage_storage_class: standard
   # We have a little over 10GB free on GHA VMs/instances
   file_storage_size: "10Gi"
   content:

--- a/config/samples/galaxy_v1beta1_galaxy_cr.s6.ci.yaml
+++ b/config/samples/galaxy_v1beta1_galaxy_cr.s6.ci.yaml
@@ -13,6 +13,7 @@ spec:
   ingress_type: nodeport
   # k3s local-path requires this
   file_storage_access_mode: "ReadWriteMany"
+  file_storage_storage_class: standard
   # We have a little over 10GB free on GHA VMs/instances
   file_storage_size: "10Gi"
   container_token_secret: "container-auth"


### PR DESCRIPTION
https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/

closes AAP-43765

```
galaxy-operator on  policies [$] via 🐍 v3.11.11 (venv) 
❯ kubectl apply -f config/samples/galaxy_v1beta1_galaxy_cr.ci.yaml             
The galaxies "example-galaxy" is invalid: : ValidatingAdmissionPolicy 'galaxy-operator-storage-type-validation' with binding 'galaxy-operator-storage-type-binding' denied request: storage_type should not be empty
galaxy-operator on  policies [$!] via 🐍 v3.11.11 (venv) 
❯ kubectl apply -f config/samples/galaxy_v1beta1_galaxy_cr.ci.yaml
The galaxies "example-galaxy" is invalid: : ValidatingAdmissionPolicy 'galaxy-operator-storage-type-validation' with binding 'galaxy-operator-storage-type-binding' denied request: please specify a rwx file_storage_storage_class
galaxy-operator on  policies [$!] via 🐍 v3.11.11 (venv) 
❯ kubectl apply -f config/samples/galaxy_v1beta1_galaxy_cr.ci.yaml
galaxy.galaxy.ansible.com/example-galaxy created
```