### PR TITLE
ci: Remove deprecated mc command

### DIFF
--- a/.ci/scripts/prepare-object-storage.sh
+++ b/.ci/scripts/prepare-object-storage.sh
@@ -17,7 +17,7 @@ elif [[ "$CI_TEST_STORAGE" == "s3" ]]; then
   while ! nc -z $(minikube ip) 9000; do echo 'Wait minio to startup...' && sleep 0.1; done;
   echo $(minikube ip)   galaxy_minio | sudo tee -a /etc/hosts
   sed -i "s/galaxy_minio/$(minikube ip)/g" config/samples/galaxy_v1beta1_galaxy_cr.galaxy.s3.ci.yaml
-  mc config host add s3 http://$(minikube ip):9000 AKIAIT2Z5TDYPX3ARJBA fqRvjWaPU5o0fCqQuUWbj9Fainj2pVZtBCiDiieS --api S3v4
-  mc config host rm local
+  mc alias set s3 http://$(minikube ip):9000 AKIAIT2Z5TDYPX3ARJBA fqRvjWaPU5o0fCqQuUWbj9Fainj2pVZtBCiDiieS --api S3v4
+  mc alias remove local
   mc mb s3/galaxy --region us-east-1
 fi


### PR DESCRIPTION
##### SUMMARY
The config mc command was deprecated and removed in recent release. Instead we should use the alias command.

##### ADDITIONAL INFORMATION
```
mc: <ERROR> `config` is not a recognized command.
```

https://github.com/minio/mc/commit/b9f30231ca641224c4b224f560f6e3b7f5a16a45
