### PR TITLE
ingress: Allow to specify the class name

### DIFF
--- a/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
@@ -229,6 +229,9 @@ spec:
               ingress_tls_secret:
                 description: Secret where the ingress TLS secret can be found
                 type: string
+              ingress_class_name:
+                description: The name of ingress class to use instead of the cluster default.
+                type: string
               nginx_client_max_body_size:
                 description: NGINX client max body size
                 default: 10m

--- a/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
@@ -198,6 +198,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes:Secret
         - urn:alm:descriptor:com.tectonic.ui:fieldDependency:ingress_type:Ingress
+      - displayName: Ingress Class Name
+        path: ingress_class_name
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+        - urn:alm:descriptor:com.tectonic.ui:fieldDependency:ingress_type:Ingress
       - displayName: LoadBalancer Annotations
         path: service_annotations
         x-descriptors:

--- a/roles/galaxy-route/templates/galaxy.ingress.yaml.j2
+++ b/roles/galaxy-route/templates/galaxy.ingress.yaml.j2
@@ -10,6 +10,9 @@ metadata:
     {{ ingress_annotations | indent(width=4) }}
 {% endif %}
 spec:
+{% if ingress_class_name is defined %}
+  ingressClassName: '{{ ingress_class_name }}'
+{% endif %}
   rules:
     - host: '{{ hostname }}'
       http:


### PR DESCRIPTION
##### SUMMARY
ingress: Allow to specify the class name

##### ADDITIONAL INFORMATION
This feature is present in all other operators but missing in this one. For feature parity, let's add it here too.
