### PR TITLE
add nginx_conf_additional_config to operator options

### DIFF
--- a/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
@@ -236,6 +236,9 @@ spec:
                 description: NGINX client max body size
                 default: 10m
                 type: string
+              nginx_conf_additional_config:
+                description: Additional config to add to NGINX's nginx.conf file generated via configmap.
+                type: string
               nginx_proxy_read_timeout:
                 description: NGINX proxy read timeout
                 default: 120s

--- a/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
@@ -223,6 +223,10 @@ spec:
         path: nginx_client_max_body_size
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:hidden
+      - displayName: Nginx conf file additional config
+        path: nginx_conf_additional_config
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
       - displayName: Nginx proxy read timeout
         path: nginx_proxy_read_timeout
         x-descriptors:

--- a/roles/galaxy-web/README.md
+++ b/roles/galaxy-web/README.md
@@ -16,6 +16,7 @@ Role Variables
 * `image_web`: The image name. Default: quay.io/ansible/galaxy-ui
 * `image_web_version`: The image tag. Default: main
 * `nginx_client_max_body_size`: Sets the maximum allowed size of the client request body.
+* `nginx_conf_additional_config`: Allows for injecting nginx configuration options into the nginx.conf configmap that is passed to the galaxy-web deployment.
 
 Requirements
 ------------

--- a/roles/galaxy-web/templates/galaxy-web.configmap.yaml.j2
+++ b/roles/galaxy-web/templates/galaxy-web.configmap.yaml.j2
@@ -86,6 +86,7 @@ data:
             # The default client_max_body_size is 1m. Clients uploading
             # files larger than this will need to chunk said files.
             client_max_body_size {{ nginx_client_max_body_size }};
+            {{ nginx_conf_additional_config | default('') }}
 
             # Gunicorn docs suggest this value.
             keepalive_timeout 5;


### PR DESCRIPTION
##### SUMMARY
I've had a need to implement a content-security-policy header for Galaxy. If there's an existing way to do this, let me know please. Otherwise, I figure I'd share my solution. It may also benefit others who require some modifications for the Galaxy web NGINX config.

##### ADDITIONAL INFORMATION
I've added an additional option, `nginx_conf_additional_config` to config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml, config/manifests/bases/galaxy-operator.clusterserviceversion.yaml, and roles/galaxy-web/templates/galaxy-web.configmap.yaml.j2 to accomplish what was mentioned in my summary. If it isn't specified, it defaults to ''.

```
