### PR TITLE
check for annotation for client_request_timeout and if present, use to override default value

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -59,6 +59,43 @@
       web_url: "https://{{ route_host }}"
   when: ingress_type | lower == 'route'
 
+- name: Look up details for this deployment
+  k8s_info:
+    api_version: "{{ api_version }}"
+    kind: "{{ kind }}"
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+  register: this_galaxy
+
+- name: "DEBUG ONE"
+  debug:
+    var: this_annotations
+
+- name: set annotations based on this_galaxy
+  set_fact:
+    this_annotations: "{{ this_galaxy['resources'][0]['metadata']['annotations'] | default({}) }}"
+
+- name: "DEBUG TWO"
+  debug:
+    var: client_request_timeout
+
+- name: set client_request_timeout based on annotation
+  set_fact:
+    client_request_timeout: "{{ (this_annotations['aap.ansible.io/client-request-timeout'][:-1]) | int }}"
+    client_request_timeout_overidden: true
+  when:
+    - "'aap.ansible.io/client-request-timeout' in this_annotations"
+    - this_annotations['aap.ansible.io/client-request-timeout'] is match('^\\d+s$')
+
+- name: "DEBUG THREE"
+  debug:
+    var: client_request_timeout_overidden
+
+- name: client_request_timeout has been changed
+  debug:
+    msg: "client_request_timeout's default 30s value has been overriden by the annotation 'aap.ansible.io/client-request-timeout' to {{ client_request_timeout }}s"
+  when: client_request_timeout_overidden | default(false)
+
 - name: Configure Postgres Configuration Secret
   include_tasks: postgres_configuration.yml
 


### PR DESCRIPTION
check for annotation for client_request_timeout and if present, use to override default value

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
