### PR TITLE
Use --no-acl flag when restoring to exclude GRANT and REVOKE commands

### DIFF
--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -94,7 +94,7 @@
 - name: Set pg_restore command
   set_fact:
     pg_restore: >-
-      pg_restore --clean --if-exists
+      pg_restore --clean --if-exists --no-owner --no-acl
       -h {{ resolvable_db_host }}
       -U {{ postgres_user }}
       -d {{ postgres_database }}


### PR DESCRIPTION


##### SUMMARY

Use --no-acl flag when restoring to exclude GRANT and REVOKE commands

  This avoids running in to the following error when pg_restore is run as
  the application db user from the db-management pod:

  pg_restore: error: could not execute query: ERROR: must be member of role postgres
  Command was: ALTER SCHEMA public OWNER TO postgres;


