### PR TITLE
Add component-specific extra volumes support

### DIFF
--- a/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
@@ -910,6 +910,24 @@ spec:
               public_base_url:
                 description: Public base URL
                 type: string
+              api_extra_volumes:
+                description: Specify extra volumes to add to API pods
+                type: string
+              api_extra_volume_mounts:
+                description: Specify volume mounts to be added to API container
+                type: string
+              content_extra_volumes:
+                description: Specify extra volumes to add to Content pods
+                type: string
+              content_extra_volume_mounts:
+                description: Specify volume mounts to be added to Content container
+                type: string
+              worker_extra_volumes:
+                description: Specify extra volumes to add to Worker pods
+                type: string
+              worker_extra_volume_mounts:
+                description: Specify volume mounts to be added to Worker container
+                type: string
             type: object
           status:
             properties:

--- a/config/samples/galaxy_v1beta1_galaxy_cr.extra_volumes.yaml
+++ b/config/samples/galaxy_v1beta1_galaxy_cr.extra_volumes.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: galaxy.ansible.com/v1beta1
+kind: Galaxy
+metadata:
+  name: galaxy-extra-volumes-example
+  namespace: galaxy
+spec:
+  # Standard Galaxy configuration
+  image: quay.io/ansible/galaxy-ng
+  image_version: latest
+  image_web: quay.io/ansible/galaxy-ui
+  image_web_version: latest
+
+  # Component-specific extra volumes example
+  # Each component defines its own volumes and mounts
+
+  # API component volumes and mounts
+  api_extra_volumes: |
+    - name: api-custom-config
+      configMap:
+        name: api-custom-config
+    - name: api-ssl-certs
+      secret:
+        secretName: api-ssl-certs
+        defaultMode: 0600
+    - name: api-shared-data
+      persistentVolumeClaim:
+        claimName: api-shared-pvc
+
+  api_extra_volume_mounts: |
+    - name: api-custom-config
+      mountPath: /etc/galaxy/api-config
+      readOnly: true
+    - name: api-ssl-certs
+      mountPath: /etc/ssl/api
+      readOnly: true
+    - name: api-shared-data
+      mountPath: /var/api-shared
+
+  # Content component volumes and mounts
+  content_extra_volumes: |
+    - name: content-media-storage
+      persistentVolumeClaim:
+        claimName: content-media-pvc
+    - name: content-temp-storage
+      emptyDir:
+        sizeLimit: 2Gi
+
+  content_extra_volume_mounts: |
+    - name: content-media-storage
+      mountPath: /var/media
+    - name: content-temp-storage
+      mountPath: /tmp/content
+
+  # Worker component volumes and mounts
+  worker_extra_volumes: |
+    - name: worker-processing-storage
+      emptyDir:
+        sizeLimit: 5Gi
+    - name: worker-logs
+      hostPath:
+        path: /var/log/galaxy-worker
+        type: DirectoryOrCreate
+
+  worker_extra_volume_mounts: |
+    - name: worker-processing-storage
+      mountPath: /tmp/worker-processing
+    - name: worker-logs
+      mountPath: /var/log/worker
+      readOnly: false
+
+  # Standard storage configuration
+  storage_type: File
+  file_storage_size: 50Gi
+  file_storage_access_mode: ReadWriteMany

--- a/docs/extra_volumes.md
+++ b/docs/extra_volumes.md
@@ -1,0 +1,211 @@
+# Extra Volumes Configuration
+
+The Galaxy operator supports mounting additional volumes in Galaxy components using the `extra_volumes` feature, following the same pattern as the AWX operator.
+
+## Overview
+
+The extra volumes feature uses component-specific fields for both volume definitions and mounting:
+
+## Supported Components
+
+Each component has its own pair of fields for defining volumes and mounting them:
+
+### API Component
+- `api_extra_volumes` - Define volumes for Galaxy API pods
+- `api_extra_volume_mounts` - Mount volumes in Galaxy API containers
+
+### Content Component
+- `content_extra_volumes` - Define volumes for Galaxy Content pods
+- `content_extra_volume_mounts` - Mount volumes in Galaxy Content containers
+
+### Worker Component
+- `worker_extra_volumes` - Define volumes for Galaxy Worker pods
+- `worker_extra_volume_mounts` - Mount volumes in Galaxy Worker containers
+
+## Configuration
+
+### Basic Example
+
+```yaml
+apiVersion: galaxy.ansible.com/v1beta1
+kind: Galaxy
+metadata:
+  name: galaxy-with-custom-volumes
+spec:
+  # Define volumes for API component
+  api_extra_volumes: |
+    - name: custom-config
+      configMap:
+        name: my-custom-config
+    - name: api-shared-storage
+      persistentVolumeClaim:
+        claimName: api-shared-pvc
+
+  # Mount volumes in API containers
+  api_extra_volume_mounts: |
+    - name: custom-config
+      mountPath: /etc/galaxy/custom
+      readOnly: true
+    - name: api-shared-storage
+      mountPath: /var/shared
+
+  # Define volumes for worker component
+  worker_extra_volumes: |
+    - name: worker-temp-storage
+      emptyDir:
+        sizeLimit: 5Gi
+
+  # Mount volumes in worker containers
+  worker_extra_volume_mounts: |
+    - name: worker-temp-storage
+      mountPath: /tmp/worker
+```
+
+### Supported Volume Types
+
+The component-specific `*_extra_volumes` fields accept standard Kubernetes volume definitions:
+
+#### ConfigMap
+
+```yaml
+api_extra_volumes: |
+  - name: app-config
+    configMap:
+      name: galaxy-config
+      items:
+        - key: config.yaml
+          path: app.yaml
+```
+
+#### Secret
+
+```yaml
+content_extra_volumes: |
+  - name: ssl-certs
+    secret:
+      secretName: tls-certificates
+      defaultMode: 0600
+```
+
+#### PersistentVolumeClaim
+
+```yaml
+worker_extra_volumes: |
+  - name: data-storage
+    persistentVolumeClaim:
+      claimName: galaxy-data-pvc
+```
+
+#### EmptyDir
+
+```yaml
+api_extra_volumes: |
+  - name: temp-storage
+    emptyDir:
+      sizeLimit: 1Gi
+```
+
+#### HostPath (use with caution)
+
+```yaml
+worker_extra_volumes: |
+  - name: host-logs
+    hostPath:
+      path: /var/log/galaxy
+      type: DirectoryOrCreate
+```
+
+### Volume Mount Options
+
+Each volume mount supports standard Kubernetes volumeMount options:
+
+```yaml
+api_extra_volume_mounts: |
+  - name: custom-config
+    mountPath: /etc/galaxy/custom    # Required: where to mount
+    subPath: config.yaml             # Optional: specific file/directory
+    readOnly: true                   # Optional: read-only mount (default: false)
+```
+
+## Use Cases
+
+### Custom Configuration Files
+
+Mount custom configuration files from ConfigMaps:
+
+```yaml
+api_extra_volumes: |
+  - name: galaxy-settings
+    configMap:
+      name: custom-galaxy-settings
+
+api_extra_volume_mounts: |
+  - name: galaxy-settings
+    mountPath: /etc/pulp/custom-settings.py
+    subPath: settings.py
+    readOnly: true
+```
+
+### SSL Certificates
+
+Mount custom SSL certificates from Secrets:
+
+```yaml
+api_extra_volumes: |
+  - name: custom-certs
+    secret:
+      secretName: galaxy-tls-certs
+
+api_extra_volume_mounts: |
+  - name: custom-certs
+    mountPath: /etc/ssl/certs/custom
+    readOnly: true
+```
+
+### Component-Specific Storage
+
+Mount different storage for different components:
+
+```yaml
+# API component gets config storage
+api_extra_volumes: |
+  - name: api-config
+    persistentVolumeClaim:
+      claimName: galaxy-api-config-pvc
+
+api_extra_volume_mounts: |
+  - name: api-config
+    mountPath: /var/api-config
+
+# Content component gets media storage
+content_extra_volumes: |
+  - name: media-storage
+    persistentVolumeClaim:
+      claimName: galaxy-media-pvc
+
+content_extra_volume_mounts: |
+  - name: media-storage
+    mountPath: /var/media
+
+# Worker component gets temp processing storage
+worker_extra_volumes: |
+  - name: temp-processing
+    emptyDir:
+      sizeLimit: 5Gi
+
+worker_extra_volume_mounts: |
+  - name: temp-processing
+    mountPath: /tmp/processing
+```
+
+## Important Notes
+
+1. **YAML Format**: The volume definitions use YAML format within the string fields
+2. **Component Targeting**: Each component has its own `*_extra_volume_mounts` field
+3. **Init Containers**: Extra volumes are also mounted in init containers for each component
+4. **Compatibility**: This feature follows the AWX operator pattern for consistency
+5. **Validation**: Ensure proper YAML syntax and valid Kubernetes volume/volumeMount specifications
+
+## Example Complete Configuration
+
+See `config/samples/galaxy_v1beta1_galaxy_cr.extra_volumes.yaml` for a complete working example.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -46,6 +46,7 @@ nav:
         - Database Configuration: user-guide/database-configuration.md
         - Content Signing: user-guide/content-signing.md
         - Storage: storage.md
+        - Extra Volumes: extra_volumes.md
   - Containers: container.md
   - Custom Resources:
       - Galaxy:

--- a/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
+++ b/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
@@ -145,6 +145,9 @@ spec:
               - path: container_auth_private_key.pem
                 key: {{ container_auth_private_key_name }}
 {% endif %}
+{% if api_extra_volumes is defined %}
+{{ api_extra_volumes | indent(8, true) }}
+{% endif %}
       serviceAccountName: '{{ ansible_operator_meta.name }}'
 {% if topology_spread_constraints %}
       topologySpreadConstraints:
@@ -280,6 +283,9 @@ spec:
               subPath: container_auth_public_key.pem
               readOnly: true
 {% endif %}
+{% if api_extra_volume_mounts is defined %}
+{{ api_extra_volume_mounts | indent(12, true) }}
+{% endif %}
       initContainers:
         - name: run-migrations
           image: {{ _image }}
@@ -319,6 +325,9 @@ spec:
             - name: file-storage
               readOnly: false
               mountPath: "/var/lib/pulp"
+{% endif %}
+{% if api_extra_volume_mounts is defined %}
+{{ api_extra_volume_mounts | indent(12, true) }}
 {% endif %}
 {% if signing_secret is defined %}
         - name: gpg-importer
@@ -385,6 +394,9 @@ spec:
               mountPath: "/etc/pulp/keys/signing_service.gpg"
               subPath: signing_service.gpg
               readOnly: true
+{% if api_extra_volume_mounts is defined %}
+{{ api_extra_volume_mounts | indent(12, true) }}
+{% endif %}
 {% endif %}
 {% if bundle_ca_crt is defined %}
         - name: configure-bundle-ca-cert
@@ -406,6 +418,9 @@ spec:
               mountPath: /etc/pki/ca-trust/source/anchors/bundle-ca.crt
               subPath: bundle-ca.crt
               readOnly: true
+{% if api_extra_volume_mounts is defined %}
+{{ api_extra_volume_mounts | indent(12, true) }}
+{% endif %}
 {% endif %}
         - name: resource-sync-job
           image: {{ _image }}

--- a/roles/galaxy-content/templates/galaxy-content.deployment.yaml.j2
+++ b/roles/galaxy-content/templates/galaxy-content.deployment.yaml.j2
@@ -120,6 +120,9 @@ spec:
         - name: tmp-file-storage
           emptyDir: {}
 {% endif %}
+{% if content_extra_volumes is defined %}
+{{ content_extra_volumes | indent(8, true) }}
+{% endif %}
       serviceAccountName: '{{ ansible_operator_meta.name }}'
 {% if topology_spread_constraints %}
       topologySpreadConstraints:
@@ -265,4 +268,7 @@ spec:
 {% else %}
             - name: tmp-file-storage
               mountPath: "/var/lib/pulp/tmp"
+{% endif %}
+{% if content_extra_volume_mounts is defined %}
+{{ content_extra_volume_mounts | indent(12, true) }}
 {% endif %}

--- a/roles/galaxy-worker/templates/galaxy-worker.deployment.yaml.j2
+++ b/roles/galaxy-worker/templates/galaxy-worker.deployment.yaml.j2
@@ -114,6 +114,9 @@ spec:
 {% endif %}
         - name: {{ ansible_operator_meta.name }}-ansible-tmp
           emptyDir: {}
+{% if worker_extra_volumes is defined %}
+{{ worker_extra_volumes | indent(8, true) }}
+{% endif %}
       serviceAccountName: '{{ ansible_operator_meta.name }}'
 {% if topology_spread_constraints %}
       topologySpreadConstraints:
@@ -193,6 +196,9 @@ spec:
             - name: gpg-file-storage
               mountPath: "/var/lib/pulp/.gnupg"
 {% endif %}
+{% endif %}
+{% if worker_extra_volume_mounts is defined %}
+{{ worker_extra_volume_mounts | indent(12, true) }}
 {% endif %}
 {% if combined_worker.resource_requirements is defined %}
           resources: {{ combined_worker.resource_requirements }}


### PR DESCRIPTION
Implements extra volumes feature following AWX operator pattern with component-specific volume definitions for better isolation and flexibility.

Features:
- Component-specific volume fields (api_extra_volumes, content_extra_volumes, worker_extra_volumes)
- Component-specific mount fields (api_extra_volume_mounts, content_extra_volume_mounts, worker_extra_volume_mounts)
- Support for all Kubernetes volume types (ConfigMap, Secret, PVC, emptyDir, hostPath)
- Integration with init containers where applicable
- Comprehensive documentation and examples

Changes:
- Updated CRD schema with component-specific volume fields
- Modified deployment templates for API, Content, and Worker components
- Added comprehensive documentation in docs/extra_volumes.md
- Created sample configuration with realistic examples
- Updated mkdocs navigation to include new documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
