### PR TITLE
restore: Remove temp files

### DIFF
--- a/roles/restore/tasks/import_vars.yml
+++ b/roles/restore/tasks/import_vars.yml
@@ -23,3 +23,8 @@
 
   - name: Include spec vars to save them as a dict
     include_vars: "{{ tmp_spec.path }}"
+
+  - name: Remove temp spec file
+    ansible.builtin.file:
+      path: "{{ tmp_spec.path }}"
+      state: absent

--- a/roles/restore/tasks/secrets.yml
+++ b/roles/restore/tasks/secrets.yml
@@ -27,6 +27,10 @@
   include_vars: "{{ tmp_secrets.path }}"
   no_log: "{{ no_log }}"
 
+- name: Remove temp secret file
+  ansible.builtin.file:
+    path: "{{ tmp_secrets.path }}"
+    state: absent
 
 # if spec_overrides is defined, use the postgres_configuration_secret from spec_overrides
 - block:


### PR DESCRIPTION
##### SUMMARY

During restore, we're creating temporary files but we never delete them.

While those files aren't very large, they contain sensitive information that persist in the running operator manager container.