### PR TITLE
backup: Fix object storage secret dump

### DIFF
--- a/roles/backup/tasks/secrets.yml
+++ b/roles/backup/tasks/secrets.yml
@@ -16,7 +16,8 @@
     - bundle_cacert_secret
     - signing_secret
     - sso_secret
-    - storage_secret
+    - object_storage_azure_secret
+    - object_storage_s3_secret
 
 # image_pull_secret is deprecated in favor of image_pull_secrets
 - name: Dump image_pull_secret into file


### PR DESCRIPTION
##### SUMMARY
When secrets are dumped then we're using `storage_secret` as the spec key that contains the secret name.

However, `storage_secret` doesn't exist at all. It should be either `object_storage_azure_secret` or `object_storage_s3_secret`.

This is a regression introduced in d2f0f26