### PR TITLE
ci: Add skipApiVersionCheck to azurite

### DIFF
--- a/.ci/scripts/prepare-object-storage.sh
+++ b/.ci/scripts/prepare-object-storage.sh
@@ -2,7 +2,7 @@
 #!/usr/bin/env bash
 
 if [[ "$CI_TEST_STORAGE" == "azure" ]]; then
-  docker run -d -p 10000:10000 --name galaxy-azurite mcr.microsoft.com/azure-storage/azurite azurite-blob --blobHost 0.0.0.0
+  docker run -d -p 10000:10000 --name galaxy-azurite mcr.microsoft.com/azure-storage/azurite azurite-blob --skipApiVersionCheck --blobHost 0.0.0.0
   sleep 5
   AZURE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://galaxy-azurite:10000/devstoreaccount1;"
   echo $(minikube ip)   galaxy-azurite | sudo tee -a /etc/hosts


### PR DESCRIPTION
##### SUMMARY

Until azurite is updated with a newer version



##### ADDITIONAL INFORMATION
```console
azure.core.exceptions.HttpResponseError: The API version 2026-02-06 is not supported by Azurite.
Please upgrade Azurite to latest version and retry. If you are using Azurite in Visual Studio, please check you have installed latest Visual Studio patch. Azurite command line parameter "--skipApiVersionCheck" or Visual Studio Code configuration "Skip Api Version Check" can skip this error.
```
