### PR TITLE
ci: Pull minio container image from quay.io

### DIFF
--- a/.ci/scripts/prepare-object-storage.sh
+++ b/.ci/scripts/prepare-object-storage.sh
@@ -12,7 +12,7 @@ elif [[ "$CI_TEST_STORAGE" == "s3" ]]; then
   export MINIO_ACCESS_KEY=AKIAIT2Z5TDYPX3ARJBA
   export MINIO_SECRET_KEY=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
   docker volume create minio
-  docker run -d -p 0.0.0.0:9000:9000 --name galaxy_minio -e MINIO_ACCESS_KEY=$MINIO_ACCESS_KEY -e MINIO_SECRET_KEY=$MINIO_SECRET_KEY -v minio:/data minio/minio server /data
+  docker run -d -p 0.0.0.0:9000:9000 --name galaxy_minio -e MINIO_ACCESS_KEY=$MINIO_ACCESS_KEY -e MINIO_SECRET_KEY=$MINIO_SECRET_KEY -v minio:/data quay.io/minio/minio:latest server /data
   wget https://dl.min.io/client/mc/release/linux-amd64/mc
   sudo mv mc /usr/local/bin/
   sudo chmod +x /usr/local/bin/mc


### PR DESCRIPTION
##### SUMMARY
Using minio/minio name for the container image pulls it from the docker hub container registry.
We should avoid this (like rate limit issues) and use alternate registry like quay.io.