### PR TITLE
postgresql: Define command when args are specified

### DIFF
--- a/roles/postgres/templates/postgres.yaml.j2
+++ b/roles/postgres/templates/postgres.yaml.j2
@@ -67,6 +67,7 @@ spec:
         - image: '{{ _postgres_image }}'
           name: postgres
 {% if postgres_extra_args %}
+          command: ["run-postgresql"]
           args: {{ postgres_extra_args }}
 {% endif %}
           env:


### PR DESCRIPTION
##### SUMMARY
When `postgres_extra_args` are defined in the CRD then we need to force the container command for the postgresql statefulset otherwise the container ends up with `CrashLoopBackOff` state

```
/usr/bin/container-entrypoint: line 3: exec: max_connections=2048: not found
```
