### PR TITLE
Add automatic backup PVC creation with create_backup_pvc option

### DIFF
--- a/config/crd/bases/galaxy_v1beta1_galaxybackup_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxybackup_crd.yaml
@@ -70,6 +70,13 @@ spec:
                 backup_storage_class:
                   description: Storage class to use when creating PVC for backup
                   type: string
+                create_backup_pvc:
+                  default: true
+                  description: Automatically create the backup PVC if it does not exist
+                  type: boolean
+                postgres_label_selector:
+                  description: Label selector used to identify postgres pod for executing migration
+                  type: string
                 no_log:
                   default: true
                   description: Configure no_log (hides sensitive information in operator/task logs)
@@ -79,9 +86,6 @@ spec:
                   type: string
                 postgres_image_version:
                   description: PostgreSQL container image version to use for backup
-                  type: string
-                postgres_label_selector:
-                  description: Label selector used to identify postgres pod for executing migration
                   type: string
               required:
                 - deployment_name

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -4,6 +4,9 @@
 
 # Specify a pre-created PVC (name) to backup to
 backup_pvc: ''
+
+# Automatically create backup PVC if it doesn't exist
+create_backup_pvc: true
 backup_pvc_namespace: "{{ ansible_operator_meta.namespace }}" # deprecated
 
 # Size of backup PVC if created dynamically

--- a/roles/backup/tasks/init.yml
+++ b/roles/backup/tasks/init.yml
@@ -24,17 +24,18 @@
   block:
     - name: Set error message
       set_fact:
-        error_msg: "{{ backup_pvc }} does not exist, please create this pvc first."
+        error_msg: "{{ backup_pvc }} does not exist, please create this pvc first or ensure create_backup_pvc is set to true (default) for automatic backup_pvc creation."
 
     - name: Handle error
       import_tasks: error_handling.yml
 
     - name: Fail early if pvc is defined but does not exist
       fail:
-        msg: "{{ backup_pvc }} does not exist, please create this pvc first."
+        msg: "{{ backup_pvc }} does not exist, please create this pvc first or ensure create_backup_pvc is set to true (default) for automatic backup_pvc creation."
   when:
     - backup_pvc != ''
     - provided_pvc.resources | length == 0
+    - not create_backup_pvc | bool
 
 - name: Set default pvc name
   set_fact:
@@ -52,7 +53,7 @@
   with_items:
     - backup
   when:
-    - backup_pvc == '' or backup_pvc is not defined
+    - (backup_pvc == '' or backup_pvc is not defined) or (create_backup_pvc | bool)
 
 - name: Remove ownerReferences from backup-claim pvc to avoid garbage collection
   k8s:


### PR DESCRIPTION
When users specify a custom backup_pvc name, the operator now automatically creates the PVC instead of failing with "does not exist, please create this pvc first."

This matches the behavior implemented in aap-gateway-operator (MR 708) and enables users to specify custom backup PVC names with automatic creation.

Changes:
- Add create_backup_pvc variable (default: true) to backup defaults
- Update error condition to check create_backup_pvc before failing
- Update PVC creation condition to include create_backup_pvc
- Add create_backup_pvc field to GalaxyBackup CRD

Users who want the previous behavior can set create_backup_pvc: false.