### PR TITLE
[AAP-64321] Add nginx log markers for direct API access detection

### DIFF
--- a/roles/galaxy-web/templates/galaxy-web.configmap.yaml.j2
+++ b/roles/galaxy-web/templates/galaxy-web.configmap.yaml.j2
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
 data:
   nginx.conf: |
-    error_log /dev/stdout info;
+    error_log /dev/stderr warn;
     worker_processes 1;
     events {
         worker_connections 1024;  # increase if you have lots of clients
@@ -20,7 +20,22 @@ data:
     }
 
     http {
-        access_log /dev/stdout;
+        map $http_x_trusted_proxy $trusted_proxy_present {
+            default "trusted-proxy";
+            ""      "-";
+        }
+
+        map $http_x_dab_jw_token $dab_jwt_present {
+            default "dab-jwt";
+            ""      "-";
+        }
+
+        log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                        '$status $body_bytes_sent "$http_referer" '
+                        '"$http_user_agent" "$http_x_forwarded_for" '
+                        '$trusted_proxy_present $dab_jwt_present';
+
+        access_log /dev/stdout main;
         include mime.types;
         # fallback in case we can't determine a type
         default_type application/octet-stream;


### PR DESCRIPTION
##### SUMMARY

Add nginx log markers to the Hub (pulpcore) nginx configuration for detecting direct API access that bypasses the AAP gateway.

This is part of [ANSTRAT-1840](https://issues.redhat.com/browse/ANSTRAT-1840) - Remove direct API access to platform components in AAP 2.7.

Changes:
- Add `map` directives for `X-Trusted-Proxy` and `X-DAB-JW-TOKEN` headers that produce log markers (`trusted-proxy`/`dab-jwt` or `-`)
- Update `log_format` to append `$trusted_proxy_present $dab_jwt_present` to each access log line
- Change `error_log` from `/dev/stdout info` to `/dev/stderr warn` for proper stderr logging

These markers allow the [aap-detect-direct-component-access](https://github.com/ansible/aap-detect-direct-component-access) tool to analyze nginx logs and identify requests made directly to Hub rather than through the AAP gateway.

The default `ingress_type: none` is already set in upstream defaults, so no route removal is needed in this repo — routes are only created when explicitly requested via the CR spec.

##### ADDITIONAL INFORMATION

Log format before:
```
access_log /dev/stdout;
```

Log format after:
```
log_format main '$remote_addr - $remote_user [$time_local] "$request" '
                '$status $body_bytes_sent "$http_referer" '
                '"$http_user_agent" "$http_x_forwarded_for" '
                '$trusted_proxy_present $dab_jwt_present';

access_log /dev/stdout main;
error_log /dev/stderr warn;
```