### PR TITLE
[AAP-60163] Update X-Forwarded-Proto

### DIFF
--- a/roles/galaxy-web/templates/galaxy-web.configmap.yaml.j2
+++ b/roles/galaxy-web/templates/galaxy-web.configmap.yaml.j2
@@ -20,6 +20,12 @@ data:
     }
 
     http {
+        map $http_x_forwarded_proto $trusted_proto {
+            default $scheme;
+            https   https;
+            http    http;
+        }
+
         map $http_x_trusted_proxy $trusted_proxy_present {
             default "trusted-proxy";
             ""      "-";
@@ -111,7 +117,7 @@ data:
 
             location {{ pulp_combined_settings.content_path_prefix | default('/pulp/content/') }} {
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header X-Forwarded-Proto $trusted_proto;
                 proxy_set_header Host $http_host;
                 # we don't want nginx trying to do something clever with
                 # redirects, we set the Host: header above already.
@@ -138,7 +144,7 @@ data:
 
             location /{{ pulp_combined_settings.galaxy_api_path_prefix }}/pulp/api/v3/ {
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header X-Forwarded-Proto $trusted_proto;
                 proxy_set_header Host $http_host;
                 # we don't want nginx trying to do something clever with
                 # redirects, we set the Host: header above already.
@@ -150,7 +156,7 @@ data:
 
             location /auth/login/ {
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header X-Forwarded-Proto $trusted_proto;
                 proxy_set_header Host $http_host;
                 # we don't want nginx trying to do something clever with
                 # redirects, we set the Host: header above already.
@@ -162,7 +168,7 @@ data:
 
             location / {
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
+                proxy_set_header X-Forwarded-Proto $trusted_proto;
                 proxy_set_header Host $http_host;
                 # we don't want nginx trying to do something clever with
                 # redirects, we set the Host: header above already.
@@ -177,7 +183,7 @@ data:
   galaxy_ng.conf: |
     location /ui/ {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $trusted_proto;
         proxy_set_header Host $http_host;
         rewrite /ui* /static/galaxy_ng/index.html break;
         # we don't want nginx trying to do something clever with
@@ -188,7 +194,7 @@ data:
 
     location /api/ {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $trusted_proto;
         proxy_set_header Host $http_host;
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
@@ -201,7 +207,7 @@ data:
   pulp_ansible.conf: |
     location /pulp_ansible/galaxy/ {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $trusted_proto;
         proxy_set_header Host $http_host;
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
@@ -213,7 +219,7 @@ data:
   pulp_container.conf: |
     location /v2/ {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $trusted_proto;
         proxy_set_header Host $http_host;
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
@@ -224,7 +230,7 @@ data:
 
     location /extensions/v2/ {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $trusted_proto;
         proxy_set_header Host $http_host;
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
@@ -234,7 +240,7 @@ data:
 
     location /pulp/container/ {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $trusted_proto;
         proxy_set_header Host $http_host;
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
@@ -244,7 +250,7 @@ data:
 
     location /token/ {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $trusted_proto;
         proxy_set_header Host $http_host;
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR changes the X-Forwarded-Proto default behavior based on the investigation in AAP-63506. This allows to preserve the original protocol header.

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

This change in conjunction with DYNACONF_AFTER_GET_HOOKS = [alter_hostname_settings] will allow for a true support of custom domains in operator based installations.