### PR TITLE
[AAP-58819] Fixing restore of /var/lib/pulp

### DIFF
--- a/roles/restore/templates/restore-content-k8s-job.yaml.j2
+++ b/roles/restore/templates/restore-content-k8s-job.yaml.j2
@@ -29,7 +29,7 @@ spec:
           - -c
           - |
             stat {{ backup_dir }}/pulp
-            cp -fr {{ backup_dir }}/pulp /var/lib/
+            cp -fr {{ backup_dir }}/pulp/. /var/lib/pulp
 {% if restore_resource_requirements is defined %}
         resources:
           {{ restore_resource_requirements | to_nice_yaml(indent=2) | indent(width=10, first=False) }}


### PR DESCRIPTION
##### SUMMARY
This PR fixes the path where pulp is restored, because now it's restored to wrong path (/var/lib/pulp/pulp/).

##### ADDITIONAL INFORMATION
N/A