### PR TITLE
Fix Galaxy Restore multiple bugs

### DIFF
--- a/roles/restore/defaults/main.yml
+++ b/roles/restore/defaults/main.yml
@@ -30,3 +30,5 @@ restore_resource_requirements:
     memory: "32Mi"
 
 spec_overrides: {}
+
+force_drop_db: false

--- a/roles/restore/tasks/postgres.yml
+++ b/roles/restore/tasks/postgres.yml
@@ -94,12 +94,23 @@
 - name: Set pg_restore command
   set_fact:
     pg_restore: >-
-      pg_restore --clean --if-exists --no-owner --no-acl
+      pg_restore {{ force_drop_db | bool | ternary('', '--clean --if-exists') }} --no-owner --no-acl
       -h {{ resolvable_db_host }}
       -U {{ postgres_user }}
       -d {{ postgres_database }}
       -p {{ postgres_port }}
   no_log: "{{ no_log }}"
+
+- name: Grant CREATEDB privilege to database user for force_drop_db
+  kubernetes.core.k8s_exec:
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    pod: "{{ postgres_pod_name }}"
+    container: postgres
+    command: >-
+      psql -c "ALTER USER {{ postgres_user }} CREATEDB;"
+  when:
+    - force_drop_db | bool
+    - postgres_type == 'managed'
 
 - name: Force drop and create database if force_drop_db is true
   block:
@@ -167,3 +178,14 @@
       "
   register: data_migration
   no_log: "{{ no_log }}"
+
+- name: Revoke CREATEDB privilege from database user
+  kubernetes.core.k8s_exec:
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    pod: "{{ postgres_pod_name }}"
+    container: postgres
+    command: >-
+      psql -c "ALTER USER {{ postgres_user }} NOCREATEDB;"
+  when:
+    - force_drop_db | bool
+    - postgres_type == 'managed'

--- a/roles/restore/vars/main.yml
+++ b/roles/restore/vars/main.yml
@@ -11,8 +11,6 @@ deployment_api_version: v1beta1
 backup_api_version: 'v1beta1'
 backup_kind: 'GalaxyBackup'
 
-# If set to true, the restore process will delete the existing database and create a new one
-force_drop_db: false
 pg_drop_create: ''
 
 is_k8s: false


### PR DESCRIPTION
##### SUMMARY
- Move force_drop_db from vars/main.yml to defaults/main.yml so CR spec values are not overridden by Ansible variable precedence
- Grant CREATEDB priv to database user before DROP/CREATE and revoke it after restore, following the containerized-installer pattern
- Omit --clean --if-exists from pg_restore when force_drop_db is true since the database is freshly created and empty, avoiding partition index dependency errors

##### ADDITIONAL INFORMATION
