### PR TITLE
manifests: Fix image index in kustomization

### DIFF
--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -12,7 +12,7 @@ replacements:
   - source:
       kind: Deployment
       name: galaxy-operator-controller-manager
-      fieldPath: spec.template.spec.containers.1.image
+      fieldPath: spec.template.spec.containers.0.image
     targets:
       - select:
           kind: ClusterServiceVersion


### PR DESCRIPTION
##### SUMMARY

Since we removed the kube rbac proxy container image as part of the operator sdk update then the container image index 1 doesn't exist anymore and we should use 0 for the controller manager.