### PR TITLE
Fix custom backup PVC name not used with create_backup_pvc

### DIFF
--- a/roles/backup/tasks/init.yml
+++ b/roles/backup/tasks/init.yml
@@ -44,7 +44,7 @@
 # by default, it will re-use the old pvc if already created (unless pvc is provided)
 - name: Set PVC to use for backup
   set_fact:
-    backup_claim: "{{ backup_pvc | default(_default_backup_pvc, true) }}"
+    backup_pvc: "{{ backup_pvc | default(_default_backup_pvc, true) }}"
 
 - name: Create persistent volume claim for backup
   k8s:
@@ -61,7 +61,7 @@
       apiVersion: v1
       kind: PersistentVolumeClaim
       metadata:
-        name: '{{ backup_claim }}'
+        name: '{{ backup_pvc }}'
         namespace: '{{ backup_pvc_namespace }}'
         ownerReferences: null
 

--- a/roles/backup/tasks/update_status.yml
+++ b/roles/backup/tasks/update_status.yml
@@ -34,7 +34,7 @@
     name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ ansible_operator_meta.namespace }}"
     status:
-      backupClaim: "{{ backup_claim }}"
+      backupClaim: "{{ backup_pvc }}"
   when: backup_complete is defined
 
 # The backup PVC namespace in this status can be referenced when restoring

--- a/roles/backup/templates/backup-content-k8s-job.yaml.j2
+++ b/roles/backup/templates/backup-content-k8s-job.yaml.j2
@@ -46,7 +46,7 @@ spec:
       volumes:
       - name: {{ ansible_operator_meta.name }}-backup
         persistentVolumeClaim:
-          claimName: {{ backup_claim }}
+          claimName: {{ backup_pvc }}
 {% if storage_claim is defined %}
       - name: file-storage
         persistentVolumeClaim:

--- a/roles/backup/templates/backup.pvc.yaml.j2
+++ b/roles/backup/templates/backup.pvc.yaml.j2
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ deployment_name }}-backup-claim
+  name: {{ backup_pvc }}
   namespace: "{{ backup_pvc_namespace }}"
   labels:
     app.kubernetes.io/name: '{{ deployment_type }}-backup-storage'

--- a/roles/backup/templates/management-pod.yaml.j2
+++ b/roles/backup/templates/management-pod.yaml.j2
@@ -41,7 +41,7 @@ spec:
   volumes:
     - name: {{ ansible_operator_meta.name }}-backup
       persistentVolumeClaim:
-        claimName: {{ backup_claim }}
+        claimName: {{ backup_pvc }}
         readOnly: false
 {% if storage_claim is defined %}
     - name: file-storage


### PR DESCRIPTION
## Summary

Fix custom backup PVC name not being used when `create_backup_pvc: true` and `backup_pvc` is specified.

## Problem

When a user specifies `backup_pvc: my-custom-pvc` with `create_backup_pvc: true`, the operator creates a PVC named `{deployment_name}-backup-claim` (the hardcoded default) instead of `my-custom-pvc`. The management pod then tries to mount the custom-named PVC which doesn't exist, causing the backup to hang.

The `backup_claim` variable was correctly resolved from `backup_pvc`, but the PVC template, management pod, backup content job, and status update all referenced `backup_claim` while the template used the hardcoded `{{ deployment_name }}-backup-claim` name instead.

## Solution

Replace the `backup_claim` variable with `backup_pvc` throughout the backup role. The `set_fact` now resolves `backup_pvc` directly (defaulting to `{deployment_name}-backup-claim` when not specified), and all templates reference `{{ backup_pvc }}`.

## Changes

- `roles/backup/tasks/init.yml`: `set_fact` resolves `backup_pvc` instead of `backup_claim`; ownerRef removal uses `{{ backup_pvc }}`
- `roles/backup/templates/backup.pvc.yaml.j2`: PVC name uses `{{ backup_pvc }}`
- `roles/backup/templates/management-pod.yaml.j2`: `claimName` uses `{{ backup_pvc }}`
- `roles/backup/templates/backup-content-k8s-job.yaml.j2`: `claimName` uses `{{ backup_pvc }}`
- `roles/backup/tasks/update_status.yml`: `backupClaim` uses `{{ backup_pvc }}`

## Testing

Tested on MicroShift with custom backup PVC names and sizes per component. All PVCs created with correct custom names and backup completed successfully.