### PR TITLE
Add use_db_compression option for backup database dumps

### DIFF
--- a/config/crd/bases/galaxy_v1beta1_galaxybackup_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxybackup_crd.yaml
@@ -87,6 +87,13 @@ spec:
                 postgres_image_version:
                   description: PostgreSQL container image version to use for backup
                   type: string
+                pg_dump_suffix:
+                  description: Additional parameters for the pg_dump command
+                  type: string
+                use_db_compression:
+                  description: Enable compression for database dumps using pg_dump built-in compression.
+                  type: boolean
+                  default: true
               required:
                 - deployment_name
             status:

--- a/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
@@ -678,6 +678,12 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Enable compression for database dumps using pg_dump built-in compression
+        displayName: Use DB Compression
+        path: use_db_compression
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       statusDescriptors:
       - displayName: Conditions
         path: conditions

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -21,6 +21,12 @@ database_type: 'unmanaged'
 
 azure_container_path: ''
 
+# Allow additional parameters to be added to the pg_dump backup command
+pg_dump_suffix: ''
+
+# Enable compression for database dumps (pg_dump -F custom built-in compression)
+use_db_compression: true
+
 # Default resource requirements
 backup_resource_requirements:
   limits:

--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -79,6 +79,8 @@
       -d {{ postgres_database }}
       -p {{ postgres_port }}
       -F custom
+      {{ use_db_compression | bool | ternary('', '-Z 0') }}
+      {{ pg_dump_suffix }}
   no_log: "{{ no_log }}"
 
 - name: Write pg_dump to backup on PVC


### PR DESCRIPTION
## Summary
- Add `use_db_compression` boolean field (default: `true`) to GalaxyBackup CRD and backup role defaults
- Also adds `pg_dump_suffix` field for consistency with other AAP operators
- When enabled (default), pg_dump uses its built-in compression within the custom format
- When disabled, passes `-Z 0` to pg_dump for uncompressed dumps
- `pg_restore` handles both compressed and uncompressed custom-format dumps transparently — no restore logic changes needed

Part of AAP-38759 (OCP Operator DB Compression).

## Test plan
- [ ] Create GalaxyBackup with default `use_db_compression: true` — verify backup succeeds
- [ ] Create GalaxyBackup with `use_db_compression: false` — verify uncompressed backup succeeds
- [ ] Restore from a compressed backup — verify succeeds
- [ ] Restore from an uncompressed backup — verify succeeds