### PR TITLE
Cycle api/content/worker deployments on upgrade

### DIFF
--- a/playbooks/check_pulp_dependency_versions.yml
+++ b/playbooks/check_pulp_dependency_versions.yml
@@ -3,6 +3,7 @@
 # Sometimes it is necessary to scale down deployments before an upgrade if there are breaking changes in the pulp dependencies.
 # Known incompatibilities to check for:
 #   * pulp_ansible < 0.23 is not compatible with 0.23.0 or later
+#   * pulpcore < 3.50 is not compatible with 3.50.0 or later
 
 - name: Check for existing API deployment
   kubernetes.core.k8s_info:
@@ -57,6 +58,17 @@
           register: _pulp_ansible_version_output
           failed_when: false
 
+        - name: Execute pulpcore-manager shell to check pulpcore version
+          kubernetes.core.k8s_exec:
+            namespace: "{{ ansible_operator_meta.namespace }}"
+            pod: "{{ _api_pods.resources[0].metadata.name }}"
+            command: >
+              bash -c "pulpcore-manager shell -c
+              \"from importlib.metadata import version; print(version('pulpcore'))\"
+              2>/dev/null || echo not_found"
+          register: _pulpcore_version_output
+          failed_when: false
+
         - name: Set scaling flag if pulp_ansible version is less than 0.23
           ansible.builtin.set_fact:
             needs_scaling_down: true
@@ -67,7 +79,17 @@
             - _pulp_ansible_version_output.stdout | trim != ''
             - _pulp_ansible_version_output.stdout | trim is version('0.23.0', '<')
 
-- name: Scale down API, Worker, and Content deployments if pulp_ansible < 0.23
+        - name: Set scaling flag if pulpcore version is less than 3.50
+          ansible.builtin.set_fact:
+            needs_scaling_down: true
+          when:
+            - _pulpcore_version_output.rc is defined
+            - _pulpcore_version_output.rc == 0
+            - _pulpcore_version_output.stdout | trim != 'not_found'
+            - _pulpcore_version_output.stdout | trim != ''
+            - _pulpcore_version_output.stdout | trim is version('3.50.0', '<')
+
+- name: Scale down API, Worker, and Content deployments if needed
   when: needs_scaling_down | default(false)
   block:
     - name: Check for all deployments to scale down


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

When upgrading with an old pulpcore version (like 3.49) to a newer one (like 3.73) then we need to scale down the api, conten and worker deployments before doing the database migration.

In the past, we already did the some regarding the pulp_ansible version so this is just doing the same when pulpcore is lower than 3.50


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

```console
RuntimeError: Incompatible versions detected (core >= 3.50.0 needed):
  - 'core'='3.49.56' with api server '3@automation-hub-api-6754f5586b-vm42g'
  - 'core'='3.49.56' with api server '2@automation-hub-api-6754f5586b-vm42g'
  - 'core'='3.49.56' with content server '6@automation-hub-content-67bbbc4f56-z868x'
  - 'core'='3.49.56' with content server '8@automation-hub-content-67bbbc4f56-z868x'
  - 'core'='3.49.56' with pulp worker '1@automation-hub-worker-6457b678c-kl772'
  - 'core'='3.49.56' with pulp worker '1@automation-hub-worker-6457b678c-t79n2' Please shutdown or upgrade the outdated components before you continue the migration. If the components were not gracefully shutdown, wait for the larger component TTL period before running the migration (API_APP_TTL, CONTENT_APP_TTL or WORKER_TTL).
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
