### PR TITLE
feat: add proxy env var support for Galaxy containers

### DIFF
--- a/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
@@ -96,6 +96,15 @@ spec:
               bundle_cacert_secret:
                 description: Secret where the trusted Certificate Authority Bundle is stored
                 type: string
+              http_proxy:
+                description: HTTP proxy URL to configure on Galaxy containers
+                type: string
+              https_proxy:
+                description: HTTPS proxy URL to configure on Galaxy containers
+                type: string
+              no_proxy:
+                description: Comma-separated list of hosts that bypass the proxy on Galaxy containers
+                type: string
               sso_secret:
                   description: Secret where Single Sign-on configuration can be found
                   type: string

--- a/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
@@ -66,6 +66,24 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
+      - description: HTTP proxy URL to configure on Galaxy containers
+        displayName: HTTP Proxy
+        path: http_proxy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: HTTPS proxy URL to configure on Galaxy containers
+        displayName: HTTPS Proxy
+        path: https_proxy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Comma-separated list of hosts that bypass the proxy on Galaxy containers
+        displayName: No Proxy
+        path: no_proxy
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Configuration secret for SSO instance
         displayName: SSO configuration
         path: sso_secret

--- a/molecule/default/tasks/proxy_env_var_test.yml
+++ b/molecule/default/tasks/proxy_env_var_test.yml
@@ -1,0 +1,144 @@
+---
+- name: Patch Galaxy CR to set proxy env vars
+  kubernetes.core.k8s:
+    state: patched
+    api_version: galaxy.ansible.com/v1beta1
+    kind: Galaxy
+    name: example-galaxy
+    namespace: '{{ namespace }}'
+    definition:
+      spec:
+        http_proxy: 'http://localhost:3128'
+        https_proxy: 'http://localhost:3128'
+        no_proxy: 'localhost,127.0.0.1,.cluster.local,.svc'
+
+# -------------------------------------------------------------------------
+# ConfigMap assertions
+# -------------------------------------------------------------------------
+- name: Wait for proxy-env ConfigMap to be created
+  kubernetes.core.k8s_info:
+    namespace: '{{ namespace }}'
+    kind: ConfigMap
+    name: 'example-galaxy-proxy-env'
+  register: proxy_configmap
+  until: proxy_configmap.resources | length > 0
+  retries: 30
+  delay: 10
+
+- name: Assert proxy-env ConfigMap has correct data
+  ansible.builtin.assert:
+    that:
+      - proxy_configmap.resources[0].data.HTTP_PROXY == 'http://localhost:3128'
+      - proxy_configmap.resources[0].data.http_proxy == 'http://localhost:3128'
+      - proxy_configmap.resources[0].data.HTTPS_PROXY == 'http://localhost:3128'
+      - proxy_configmap.resources[0].data.https_proxy == 'http://localhost:3128'
+      - proxy_configmap.resources[0].data.NO_PROXY == 'localhost,127.0.0.1,.cluster.local,.svc'
+      - proxy_configmap.resources[0].data.no_proxy == 'localhost,127.0.0.1,.cluster.local,.svc'
+    fail_msg: proxy-env ConfigMap is missing one or more expected proxy values
+
+# -------------------------------------------------------------------------
+# Deployment envFrom assertions
+# -------------------------------------------------------------------------
+- name: Get galaxy-api deployment
+  kubernetes.core.k8s_info:
+    namespace: '{{ namespace }}'
+    kind: Deployment
+    label_selectors:
+      - app.kubernetes.io/name = galaxy-api
+  register: api_deployment
+
+- name: Assert galaxy-api containers reference proxy-env ConfigMap via envFrom
+  ansible.builtin.assert:
+    that:
+      - api_deployment.resources[0].spec.template.spec.containers |
+        map(attribute='envFrom', default=[]) | flatten |
+        selectattr('configMapRef.name', 'defined') |
+        selectattr('configMapRef.name', 'equalto', 'example-galaxy-proxy-env') | list | length > 0
+    fail_msg: galaxy-api containers are missing envFrom reference to example-galaxy-proxy-env
+
+- name: Get galaxy-worker deployment
+  kubernetes.core.k8s_info:
+    namespace: '{{ namespace }}'
+    kind: Deployment
+    label_selectors:
+      - app.kubernetes.io/name = galaxy-worker
+  register: worker_deployment
+
+- name: Assert galaxy-worker containers reference proxy-env ConfigMap via envFrom
+  ansible.builtin.assert:
+    that:
+      - worker_deployment.resources[0].spec.template.spec.containers |
+        map(attribute='envFrom', default=[]) | flatten |
+        selectattr('configMapRef.name', 'defined') |
+        selectattr('configMapRef.name', 'equalto', 'example-galaxy-proxy-env') | list | length > 0
+    fail_msg: galaxy-worker containers are missing envFrom reference to example-galaxy-proxy-env
+
+- name: Get galaxy-content deployment
+  kubernetes.core.k8s_info:
+    namespace: '{{ namespace }}'
+    kind: Deployment
+    label_selectors:
+      - app.kubernetes.io/name = galaxy-content
+  register: content_deployment
+
+- name: Assert galaxy-content containers reference proxy-env ConfigMap via envFrom
+  ansible.builtin.assert:
+    that:
+      - content_deployment.resources[0].spec.template.spec.containers |
+        map(attribute='envFrom', default=[]) | flatten |
+        selectattr('configMapRef.name', 'defined') |
+        selectattr('configMapRef.name', 'equalto', 'example-galaxy-proxy-env') | list | length > 0
+    fail_msg: galaxy-content containers are missing envFrom reference to example-galaxy-proxy-env
+
+# -------------------------------------------------------------------------
+# Cleanup and verify ConfigMap removal
+# -------------------------------------------------------------------------
+- name: Clear proxy env vars from Galaxy CR after test
+  kubernetes.core.k8s:
+    state: patched
+    api_version: galaxy.ansible.com/v1beta1
+    kind: Galaxy
+    name: example-galaxy
+    namespace: '{{ namespace }}'
+    definition:
+      spec:
+        http_proxy: null
+        https_proxy: null
+        no_proxy: null
+
+- name: Wait for proxy-env ConfigMap to be deleted
+  kubernetes.core.k8s_info:
+    namespace: '{{ namespace }}'
+    kind: ConfigMap
+    name: 'example-galaxy-proxy-env'
+  register: proxy_configmap_after
+  until: proxy_configmap_after.resources | length == 0
+  retries: 30
+  delay: 10
+
+- name: Assert proxy-env ConfigMap is removed when proxy vars cleared
+  ansible.builtin.assert:
+    that:
+      - proxy_configmap_after.resources | length == 0
+    fail_msg: proxy-env ConfigMap still exists after clearing proxy vars from CR
+
+# -------------------------------------------------------------------------
+# Recovery wait — ensure content app is healthy before next test file runs.
+# Without this, alphabetical test ordering causes proxy_env_var_test.yml to
+# run before pulp_test.yml. In S3 mode the content app restarts after the
+# proxy patch/cleanup cycle, and pulp_test.yml's online_content_apps check
+# fails if the pod has not come back up.
+# -------------------------------------------------------------------------
+- name: Wait for galaxy-content deployment to be fully ready after proxy cleanup
+  kubernetes.core.k8s_info:
+    namespace: '{{ namespace }}'
+    kind: Deployment
+    label_selectors:
+      - app.kubernetes.io/name = galaxy-content
+  register: content_recovery
+  until:
+    - content_recovery.resources | length > 0
+    - content_recovery.resources[0].status.readyReplicas is defined
+    - content_recovery.resources[0].status.readyReplicas == content_recovery.resources[0].spec.replicas
+  retries: 30
+  delay: 10

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -4,6 +4,14 @@ image_pull_secrets: []
 operator_service_account_name: '{{ lookup("env","OPERATOR_SA_NAME") | default("galaxy-operator-sa",true) }}'
 bundle_cacert_secret: ''
 
+# Proxy environment variables for Galaxy containers.
+# Defaults inherit from the operator pod environment (e.g. set by the OCP cluster
+# proxy object). Set these fields in the CR spec to override the inherited values
+# per instance.
+http_proxy: "{{ lookup('env', 'http_proxy') or lookup('env', 'HTTP_PROXY') or '' }}"
+https_proxy: "{{ lookup('env', 'https_proxy') or lookup('env', 'HTTPS_PROXY') or '' }}"
+no_proxy: "{{ lookup('env', 'no_proxy') or lookup('env', 'NO_PROXY') or '' }}"
+
 is_k8s: false
 is_openshift: false
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -8,6 +8,16 @@
     combined_worker: "{{ _worker | combine(worker, recursive=True) }}"
     combined_redis: "{{ _redis | combine(redis, recursive=True) }}"
 
+- name: Set proxy vars from CR spec
+  # TODO: Investigate why these fields require explicit raw_spec extraction while
+  # bundle_cacert_secret (also a top-level string in defaults/main.yml) works via
+  # the operator framework's normal spec-merge without this task. Possible causes:
+  # CRD not applied before first test run, or a framework quirk with newly-added fields.
+  ansible.builtin.set_fact:
+    http_proxy: "{{ raw_spec.http_proxy | default(http_proxy) }}"
+    https_proxy: "{{ raw_spec.https_proxy | default(https_proxy) }}"
+    no_proxy: "{{ raw_spec.no_proxy | default(no_proxy) }}"
+
 - name: Set apiVersion and kind variables
   ansible.builtin.set_fact:
     api_version: '{{ hostvars["localhost"]["inventory_file"].split("/")[4:6] | join("/")  }}'
@@ -119,3 +129,9 @@
 
 - name: Set application images
   include_tasks: set_images.yml
+
+- name: Apply proxy environment ConfigMap
+  k8s:
+    apply: yes
+    definition: "{{ lookup('template', 'proxy-env.configmap.yaml.j2') }}"
+    state: "{{ 'present' if (http_proxy or https_proxy or no_proxy) else 'absent' }}"

--- a/roles/common/templates/proxy-env.configmap.yaml.j2
+++ b/roles/common/templates/proxy-env.configmap.yaml.j2
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: '{{ ansible_operator_meta.name }}-proxy-env'
+  namespace: '{{ ansible_operator_meta.namespace }}'
+data:
+{% if http_proxy %}
+  HTTP_PROXY: '{{ http_proxy }}'
+  http_proxy: '{{ http_proxy }}'
+{% endif %}
+{% if https_proxy %}
+  HTTPS_PROXY: '{{ https_proxy }}'
+  https_proxy: '{{ https_proxy }}'
+{% endif %}
+{% if no_proxy %}
+  NO_PROXY: '{{ no_proxy }}'
+  no_proxy: '{{ no_proxy }}'
+{% endif %}

--- a/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
+++ b/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
@@ -58,6 +58,9 @@ spec:
   ] %}
         checksum-secret-{{ secret }}: "{{ lookup('ansible.builtin.vars', secret, default='')["resources"][0]["data"] | default('') | sha1 }}"
 {% endfor %}
+{% if http_proxy or https_proxy or no_proxy %}
+        checksum-proxy-env-configmap: "{{ lookup('template', '../common/templates/proxy-env.configmap.yaml.j2') | sha1 }}"
+{% endif %}
     spec:
 {% if api_affinity is defined and api_affinity | length > 0 %}
       affinity:
@@ -197,6 +200,10 @@ spec:
             - name: GNUPGHOME
               value: "/var/lib/pulp/.gnupg"
 {% endif %}
+          envFrom:
+            - configMapRef:
+                name: '{{ ansible_operator_meta.name }}-proxy-env'
+                optional: true
           ports:
             - protocol: TCP
               containerPort: 8000

--- a/roles/galaxy-content/templates/galaxy-content.deployment.yaml.j2
+++ b/roles/galaxy-content/templates/galaxy-content.deployment.yaml.j2
@@ -59,6 +59,9 @@ spec:
   ] %}
         checksum-secret-{{ secret }}: "{{ lookup('ansible.builtin.vars', secret, default='')["resources"][0]["data"] | default('') | sha1 }}"
 {% endfor %}
+{% if http_proxy or https_proxy or no_proxy %}
+        checksum-proxy-env-configmap: "{{ lookup('template', '../common/templates/proxy-env.configmap.yaml.j2') | sha1 }}"
+{% endif %}
     spec:
 {% if content_affinity is defined and content_affinity | length > 0 %}
       affinity:
@@ -218,6 +221,10 @@ spec:
             - name: PULP_SIGNING_KEY_FINGERPRINT
               value: "{{ signing_key_fingerprint }}"
 {% endif %}
+          envFrom:
+            - configMapRef:
+                name: '{{ ansible_operator_meta.name }}-proxy-env'
+                optional: true
           ports:
             - protocol: TCP
               containerPort: 24816

--- a/roles/galaxy-web/templates/galaxy-web.deployment.yaml.j2
+++ b/roles/galaxy-web/templates/galaxy-web.deployment.yaml.j2
@@ -42,6 +42,10 @@ spec:
         app.kubernetes.io/component: webserver
         app.kubernetes.io/part-of: '{{ deployment_type }}'
         app.kubernetes.io/managed-by: '{{ deployment_type }}-operator'
+      annotations:
+{% if http_proxy or https_proxy or no_proxy %}
+        checksum-proxy-env-configmap: "{{ lookup('template', '../common/templates/proxy-env.configmap.yaml.j2') | sha1 }}"
+{% endif %}
     spec:
 {% if web_affinity is defined and web_affinity | length > 0 %}
       affinity:
@@ -73,6 +77,10 @@ spec:
                 fieldRef:
                   fieldPath: status.hostIP
 {% endif %}
+          envFrom:
+            - configMapRef:
+                name: '{{ ansible_operator_meta.name }}-proxy-env'
+                optional: true
           volumeMounts:
             - name: {{ ansible_operator_meta.name }}-nginx-conf
               mountPath: /etc/nginx/nginx.conf

--- a/roles/galaxy-worker/templates/galaxy-worker.deployment.yaml.j2
+++ b/roles/galaxy-worker/templates/galaxy-worker.deployment.yaml.j2
@@ -52,6 +52,9 @@ spec:
   ] %}
         checksum-secret-{{ secret }}: "{{ lookup('ansible.builtin.vars', secret, default='')["resources"][0]["data"] | default('') | sha1 }}"
 {% endfor %}
+{% if http_proxy or https_proxy or no_proxy %}
+        checksum-proxy-env-configmap: "{{ lookup('template', '../common/templates/proxy-env.configmap.yaml.j2') | sha1 }}"
+{% endif %}
     spec:
 {% if worker_affinity is defined and worker_affinity | length > 0 %}
       affinity:
@@ -152,6 +155,10 @@ spec:
             - name: GNUPGHOME
               value: "/var/lib/pulp/.gnupg"
 {% endif %}
+          envFrom:
+            - configMapRef:
+                name: '{{ ansible_operator_meta.name }}-proxy-env'
+                optional: true
           volumeMounts:
             - name: {{ ansible_operator_meta.name }}-ansible-tmp
               mountPath: "/.ansible/tmp/"


### PR DESCRIPTION
##### SUMMARY
Add http_proxy, https_proxy, and no_proxy CRD fields to the Galaxy spec.

Add the proxy-aware OLM annotation to the CSV so that OLM injects cluster proxy configuration into the operator manager pod.

##### ADDITIONAL INFORMATION

