### PR TITLE
fix: add missing nginx timeout defaults to galaxy-web role

### DIFF
--- a/roles/galaxy-web/defaults/main.yml
+++ b/roles/galaxy-web/defaults/main.yml
@@ -30,3 +30,12 @@ galaxy_nginx_conf_dir: "/etc/nginx/default.d"
 # Here we use  _galaxy_ansible_com_galaxy to get un-modified cr
 # see: https://github.com/operator-framework/operator-sdk/issues/1770
 raw_spec: "{{ vars['_galaxy_ansible_com_galaxy']['spec'] }}"
+
+# Nginx timeout and body size defaults. These variables are also defined in
+# galaxy-route/defaults but are used directly in galaxy-web templates. Defining
+# them here ensures they are always in scope when the galaxy-web role runs.
+client_request_timeout: 30
+nginx_client_max_body_size: 10m
+nginx_proxy_read_timeout: '{{ (([(client_request_timeout | int), 10] | max) / 2) | int }}'
+nginx_proxy_connect_timeout: '{{ (([(client_request_timeout | int), 10] | max) / 2) | int }}'
+nginx_proxy_send_timeout: '{{ (([(client_request_timeout | int), 10] | max) / 2) | int }}'


### PR DESCRIPTION
##### SUMMARY
galaxy-web templates use nginx_proxy_read_timeout, nginx_proxy_connect_timeout, nginx_proxy_send_timeout, and nginx_client_max_body_size, but these variables are only defined in galaxy-route/defaults.

Add them to galaxy-web/defaults so the role always has them in scope regardless of playbook execution order. client_request_timeout is also added as the base variable used in the computed timeout expressions.

##### ADDITIONAL INFORMATION

