### PR TITLE
Fix backup creating duplicate artifact directory

### DIFF
--- a/roles/backup/templates/backup-content-k8s-job.yaml.j2
+++ b/roles/backup/templates/backup-content-k8s-job.yaml.j2
@@ -30,7 +30,6 @@ spec:
           - |
             mkdir -p {{ _backup_dir }}/pulp
             if [ -d "/var/lib/pulp/media" ]; then cp -fr /var/lib/pulp/media {{ _backup_dir }}/pulp/; fi
-            if [ -d "/var/lib/pulp/media/artifact" ]; then cp -fr /var/lib/pulp/media/artifact {{ _backup_dir }}/pulp/; fi
             if [ -d "/var/lib/pulp/scripts" ]; then cp -fr /var/lib/pulp/scripts {{ _backup_dir }}/pulp/; fi
 {% if backup_resource_requirements is defined %}
         resources:


### PR DESCRIPTION
## Summary

- Remove redundant `cp` of `/var/lib/pulp/media/artifact` in the backup content job template
- The `media/` directory copy already includes `media/artifact/` as a subdirectory, so the separate copy created a duplicate at `<backup>/pulp/artifact/`, doubling disk space consumption for artifacts

Fixes: AAP-72548

## Test plan

- [ ] Create a GalaxyBackup CR with file-based storage after syncing at least one collection
- [ ] Verify the backup PVC contains `pulp/media/artifact/` but NOT a separate `pulp/artifact/` directory
- [ ] Verify restore from the backup succeeds and artifacts are accessible