### PR TITLE
 [AAP-69897] Define default handlers and loggers for collection import 

### DIFF
--- a/playbooks/galaxy.yaml
+++ b/playbooks/galaxy.yaml
@@ -30,18 +30,18 @@
       redis_port: 6379
       redis_password: ""
       LOGGING:
-        dynaconf_merge: "True"
+        dynaconf_merge: True
         handlers:
           collection_import:
-            level: "INFO"
-            class: "pulp_ansible.app.logutils.CollectionImportHandler"
-            formatter: "simple"
+            level: INFO
+            class: pulp_ansible.app.logutils.CollectionImportHandler
+            formatter: simple
         loggers:
           pulp_ansible.app.tasks.upload.process_collection_artifact:
-            level: "INFO"
+            level: INFO
             handlers:
-              - "collection_import"
-            propagate: "False"
+              - collection_import
+            propagate: False
     deployment_state: present
     _image: quay.io/ansible/galaxy-ng
     _image_version: "{{ lookup('env', 'DEFAULT_GALAXY_VERSION') or 'latest' }}"

--- a/playbooks/galaxy.yaml
+++ b/playbooks/galaxy.yaml
@@ -29,6 +29,19 @@
       redis_host: "{{ ansible_operator_meta.name }}-redis-svc"
       redis_port: 6379
       redis_password: ""
+      LOGGING:
+        dynaconf_merge: true
+        handlers:
+          collection_import:
+            level: INFO
+            class: pulp_ansible.app.logutils.CollectionImportHandler
+            formatter: simple
+        loggers:
+          pulp_ansible.app.tasks.upload.process_collection_artifact:
+            level: INFO
+            handlers:
+              - collection_import
+            propagate: false
     deployment_state: present
     _image: quay.io/ansible/galaxy-ng
     _image_version: "{{ lookup('env', 'DEFAULT_GALAXY_VERSION') or 'latest' }}"

--- a/playbooks/galaxy.yaml
+++ b/playbooks/galaxy.yaml
@@ -30,7 +30,7 @@
       redis_port: 6379
       redis_password: ""
       LOGGING:
-        dynaconf_merge: True
+        dynaconf_merge: '@bool True'
         handlers:
           collection_import:
             level: INFO
@@ -41,7 +41,7 @@
             level: INFO
             handlers:
               - collection_import
-            propagate: False
+            propagate: '@bool False'
     deployment_state: present
     _image: quay.io/ansible/galaxy-ng
     _image_version: "{{ lookup('env', 'DEFAULT_GALAXY_VERSION') or 'latest' }}"

--- a/playbooks/galaxy.yaml
+++ b/playbooks/galaxy.yaml
@@ -30,18 +30,18 @@
       redis_port: 6379
       redis_password: ""
       LOGGING:
-        dynaconf_merge: true
+        dynaconf_merge: "True"
         handlers:
           collection_import:
-            level: INFO
-            class: pulp_ansible.app.logutils.CollectionImportHandler
-            formatter: simple
+            level: "INFO"
+            class: "pulp_ansible.app.logutils.CollectionImportHandler"
+            formatter: "simple"
         loggers:
           pulp_ansible.app.tasks.upload.process_collection_artifact:
-            level: INFO
+            level: "INFO"
             handlers:
-              - collection_import
-            propagate: false
+              - "collection_import"
+            propagate: "False"
     deployment_state: present
     _image: quay.io/ansible/galaxy-ng
     _image_version: "{{ lookup('env', 'DEFAULT_GALAXY_VERSION') or 'latest' }}"


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/AAP-69897

We started seeing test failures in 2.7 related to the empty collection import log. After investigating, this is related to the pulpcore changes in 3.73 (which we bumped to as part of the Django 5.2 upgrade) and how it loads plugins: https://github.com/pulp/pulpcore/blob/154c8f50e26812f60308f7e0d743930762e4bfce/pulpcore/app/settings.py#L526-L528

Now all installers require to have this setting defined. Similar containerized installer change https://gitlab.cee.redhat.com/ansible/aap-containerized-installer/-/merge_requests/1020