### PR TITLE
refactor: remove proxy env var CRD fields and CSV specDescriptors

### DIFF
--- a/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
@@ -96,15 +96,6 @@ spec:
               bundle_cacert_secret:
                 description: Secret where the trusted Certificate Authority Bundle is stored
                 type: string
-              http_proxy:
-                description: HTTP proxy URL to configure on Galaxy containers
-                type: string
-              https_proxy:
-                description: HTTPS proxy URL to configure on Galaxy containers
-                type: string
-              no_proxy:
-                description: Comma-separated list of hosts that bypass the proxy on Galaxy containers
-                type: string
               sso_secret:
                   description: Secret where Single Sign-on configuration can be found
                   type: string

--- a/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
@@ -66,24 +66,6 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
-      - description: HTTP proxy URL to configure on Galaxy containers
-        displayName: HTTP Proxy
-        path: http_proxy
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: HTTPS proxy URL to configure on Galaxy containers
-        displayName: HTTPS Proxy
-        path: https_proxy
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:text
-      - description: Comma-separated list of hosts that bypass the proxy on Galaxy containers
-        displayName: No Proxy
-        path: no_proxy
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:advanced
-        - urn:alm:descriptor:com.tectonic.ui:text
       - description: Configuration secret for SSO instance
         displayName: SSO configuration
         path: sso_secret

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -5,9 +5,7 @@ operator_service_account_name: '{{ lookup("env","OPERATOR_SA_NAME") | default("g
 bundle_cacert_secret: ''
 
 # Proxy environment variables for Galaxy containers.
-# Defaults inherit from the operator pod environment (e.g. set by the OCP cluster
-# proxy object). Set these fields in the CR spec to override the inherited values
-# per instance.
+# Values are inherited from the operator pod environment.
 http_proxy: "{{ lookup('env', 'http_proxy') or lookup('env', 'HTTP_PROXY') or '' }}"
 https_proxy: "{{ lookup('env', 'https_proxy') or lookup('env', 'HTTPS_PROXY') or '' }}"
 no_proxy: "{{ lookup('env', 'no_proxy') or lookup('env', 'NO_PROXY') or '' }}"


### PR DESCRIPTION
## Summary

- Removes `http_proxy`, `https_proxy`, and `no_proxy` from the CRD spec
  and CSV specDescriptors
- Proxy configuration is injected into the operator pod environment and
  propagated to containers via the existing ConfigMap mechanism

## Test plan

- [x] Verify operator reconciles cleanly with no failed tasks
- [x] Verify proxy environment variables are not exposed in CRD spec