### PR TITLE
Fix S3-compatible storage SignatureDoesNotMatch with botocore >= 1.36.0

### DIFF
--- a/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
+++ b/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
@@ -200,6 +200,12 @@ spec:
             - name: GNUPGHOME
               value: "/var/lib/pulp/.gnupg"
 {% endif %}
+{% if object_storage_s3_secret is defined %}
+            - name: AWS_REQUEST_CHECKSUM_CALCULATION
+              value: "when_required"
+            - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+              value: "when_required"
+{% endif %}
           envFrom:
             - configMapRef:
                 name: '{{ ansible_operator_meta.name }}-proxy-env'

--- a/roles/galaxy-content/templates/galaxy-content.deployment.yaml.j2
+++ b/roles/galaxy-content/templates/galaxy-content.deployment.yaml.j2
@@ -221,6 +221,12 @@ spec:
             - name: PULP_SIGNING_KEY_FINGERPRINT
               value: "{{ signing_key_fingerprint }}"
 {% endif %}
+{% if object_storage_s3_secret is defined %}
+            - name: AWS_REQUEST_CHECKSUM_CALCULATION
+              value: "when_required"
+            - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+              value: "when_required"
+{% endif %}
           envFrom:
             - configMapRef:
                 name: '{{ ansible_operator_meta.name }}-proxy-env'

--- a/roles/galaxy-worker/templates/galaxy-worker.deployment.yaml.j2
+++ b/roles/galaxy-worker/templates/galaxy-worker.deployment.yaml.j2
@@ -155,6 +155,12 @@ spec:
             - name: GNUPGHOME
               value: "/var/lib/pulp/.gnupg"
 {% endif %}
+{% if object_storage_s3_secret is defined %}
+            - name: AWS_REQUEST_CHECKSUM_CALCULATION
+              value: "when_required"
+            - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+              value: "when_required"
+{% endif %}
           envFrom:
             - configMapRef:
                 name: '{{ ansible_operator_meta.name }}-proxy-env'


### PR DESCRIPTION
## Summary

- Fix `SignatureDoesNotMatch` errors on non-AWS S3-compatible storage backends (Google Cloud Storage, NooBaa/ODF, MinIO, Ceph, etc.) caused by botocore >= 1.36.0 defaulting to CRC32 checksums
- Set `AWS_REQUEST_CHECKSUM_CALCULATION=when_required` and `AWS_RESPONSE_CHECKSUM_VALIDATION=when_required` env vars on hub api, content, and worker pods when S3 storage is configured
- Safe for all backends including AWS S3 — restores pre-1.36.0 behavior

## Root Cause

[botocore 1.36.0](https://github.com/boto/botocore/blob/develop/CHANGELOG.rst) (Jan 2025) introduced default CRC32 checksum computation on S3 write operations via the `x-amz-sdk-checksum-algorithm` header. Non-AWS S3-compatible backends don't recognize this header, causing signature verification to fail.

Related upstream issues:
- https://github.com/boto/boto3/issues/4400
- https://github.com/jschneier/django-storages/issues/1482

## Test Plan

- [ ] Deploy with S3 storage configured → verify env vars present on hub pods
- [ ] Upload collection artifact → verify no `SignatureDoesNotMatch` error
- [ ] Deploy with file storage → verify env vars are NOT set
- [ ] Deploy with Azure storage → verify env vars are NOT set

Fixes: AAP-75239