### PR TITLE
Add configurable S3 checksum env vars for botocore >= 1.36.0

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -103,7 +103,15 @@ stringData:
   s3-bucket-name: "galaxy-storage"
   s3-region: "us-west-2"
   s3-endpoint: "https://s3.amazonaws.com"  # Optional, defaults to AWS
+  s3-request-checksum-calculation: "when_required"  # Optional, defaults to "when_required"
+  s3-response-checksum-validation: "when_required"  # Optional, defaults to "when_required"
 ```
+
+#### S3 Checksum Configuration
+
+The `s3-request-checksum-calculation` and `s3-response-checksum-validation` keys control botocore's automatic checksum behavior. Starting with botocore 1.36.0, the SDK computes CRC32 checksums on S3 write operations by default. This can cause `SignatureDoesNotMatch` errors with non-AWS S3-compatible backends (MinIO, Ceph, Google Cloud Storage, etc.) that do not support the `x-amz-sdk-checksum-algorithm` header.
+
+Both keys default to `when_required`, which restores pre-1.36.0 behavior and is compatible with all S3 backends including AWS S3. Set to `when_supported` if you need to enforce checksum calculation on every request (only supported by AWS S3).
 
 2. Reference the secret in your Galaxy CR:
 

--- a/roles/common/tasks/s3-storage-configuration.yml
+++ b/roles/common/tasks/s3-storage-configuration.yml
@@ -139,6 +139,22 @@
   when:
     - s3_endpoint_available
 
+- name: Store s3 request checksum calculation
+  set_fact:
+    s3_request_checksum_calculation: "{{ _custom_s3_configuration['resources'][0]['data']['s3-request-checksum-calculation'] | b64decode }}"
+  when:
+    - s3_secret_data_available
+    - _custom_s3_configuration.resources[0].data['s3-request-checksum-calculation'] is defined
+    - _custom_s3_configuration.resources[0].data['s3-request-checksum-calculation'] | length
+
+- name: Store s3 response checksum validation
+  set_fact:
+    s3_response_checksum_validation: "{{ _custom_s3_configuration['resources'][0]['data']['s3-response-checksum-validation'] | b64decode }}"
+  when:
+    - s3_secret_data_available
+    - _custom_s3_configuration.resources[0].data['s3-response-checksum-validation'] is defined
+    - _custom_s3_configuration.resources[0].data['s3-response-checksum-validation'] | length
+
 - name: Add s3 access key id to s3 settings
   set_fact:
     s3_access_key_id_dict:

--- a/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
+++ b/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
@@ -200,6 +200,12 @@ spec:
             - name: GNUPGHOME
               value: "/var/lib/pulp/.gnupg"
 {% endif %}
+{% if object_storage_s3_secret is defined %}
+            - name: AWS_REQUEST_CHECKSUM_CALCULATION
+              value: "{{ s3_request_checksum_calculation | default('when_required') }}"
+            - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+              value: "{{ s3_response_checksum_validation | default('when_required') }}"
+{% endif %}
           envFrom:
             - configMapRef:
                 name: '{{ ansible_operator_meta.name }}-proxy-env'

--- a/roles/galaxy-content/templates/galaxy-content.deployment.yaml.j2
+++ b/roles/galaxy-content/templates/galaxy-content.deployment.yaml.j2
@@ -221,6 +221,12 @@ spec:
             - name: PULP_SIGNING_KEY_FINGERPRINT
               value: "{{ signing_key_fingerprint }}"
 {% endif %}
+{% if object_storage_s3_secret is defined %}
+            - name: AWS_REQUEST_CHECKSUM_CALCULATION
+              value: "{{ s3_request_checksum_calculation | default('when_required') }}"
+            - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+              value: "{{ s3_response_checksum_validation | default('when_required') }}"
+{% endif %}
           envFrom:
             - configMapRef:
                 name: '{{ ansible_operator_meta.name }}-proxy-env'

--- a/roles/galaxy-worker/templates/galaxy-worker.deployment.yaml.j2
+++ b/roles/galaxy-worker/templates/galaxy-worker.deployment.yaml.j2
@@ -155,6 +155,12 @@ spec:
             - name: GNUPGHOME
               value: "/var/lib/pulp/.gnupg"
 {% endif %}
+{% if object_storage_s3_secret is defined %}
+            - name: AWS_REQUEST_CHECKSUM_CALCULATION
+              value: "{{ s3_request_checksum_calculation | default('when_required') }}"
+            - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+              value: "{{ s3_response_checksum_validation | default('when_required') }}"
+{% endif %}
           envFrom:
             - configMapRef:
                 name: '{{ ansible_operator_meta.name }}-proxy-env'


### PR DESCRIPTION
## Summary

- Adds two optional keys to the S3 storage secret: `s3-request-checksum-calculation` and `s3-response-checksum-validation`
- Both default to `when_required` (pre-botocore 1.36.0 behavior), which is safe for all S3 backends
- Users who need checksum enforcement on AWS S3 can set these to `when_supported`
- Sets the values as env vars (`AWS_REQUEST_CHECKSUM_CALCULATION`, `AWS_RESPONSE_CHECKSUM_VALIDATION`) on galaxy-api, galaxy-content, and galaxy-worker deployments

## Context

botocore >= 1.36.0 (January 2025) automatically computes CRC32 checksums on S3 write operations. Non-AWS S3-compatible backends (GCS, MinIO, Ceph, Backblaze B2, etc.) do not support the `x-amz-sdk-checksum-algorithm` header, causing `SignatureDoesNotMatch` errors.

Defaulting to `when_required` restores pre-1.36.0 behavior while keeping the setting configurable for users who want checksum enforcement on native AWS S3.

## Ref

- [AAP-75239](https://redhat.atlassian.net/browse/AAP-75239)
- [boto/boto3#4400](https://github.com/boto/boto3/issues/4400)
- [django-storages#1482](https://github.com/jschneier/django-storages/issues/1482)