### PR TITLE
deprecate: mark postgres_keep_pvc_after_upgrade deprecated and remove implementation

### DIFF
--- a/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
+++ b/config/crd/bases/galaxy_v1beta1_galaxy_crd.yaml
@@ -330,7 +330,7 @@ spec:
                 description: nodeSelector for the Postgres pods
                 type: string
               postgres_keep_pvc_after_upgrade:
-                description: Specify whether or not to keep the old PVC after PostgreSQL upgrades
+                description: "(Deprecated) Specify whether or not to keep the old PVC after PostgreSQL upgrades"
                 type: boolean
               postgres_tolerations:
                 description: node tolerations for the Postgres pods

--- a/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
@@ -141,11 +141,6 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:hidden
         - urn:alm:descriptor:io.kubernetes:Secret
-      - displayName: Postgres Keep Old Data PVC After Upgrade
-        path: postgres_keep_pvc_after_upgrade
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:hidden
-        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - displayName: Database backup label selector
         path: postgres_label_selector
         x-descriptors:

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -19,9 +19,6 @@ postgres_host_auth_method: 'scram-sha-256'
 #   kubernetes.io/os: linux
 postgres_selector: ''
 
-# Specify whether or not to keep the old PVC after PostgreSQL upgrades
-postgres_keep_pvc_after_upgrade: false
-
 # Add node tolerations for the Postgres pods.
 # Specify as literal block. E.g.:
 # postgres_tolerations: |

--- a/roles/postgres/tasks/upgrade_postgres.yml
+++ b/roles/postgres/tasks/upgrade_postgres.yml
@@ -285,31 +285,6 @@
     namespace: "{{ ansible_operator_meta.namespace }}"
     conditions:
       - type: Database-Ready
-        message: Removing old Postgres PVC
-        reason: RemovingOldPostgresPVC
-        status: "False"
-        lastTransitionTime: "{{ lookup('pipe', 'date --iso-8601=seconds') }}"
-
-- name: Remove old persistent volume claim
-  k8s:
-    kind: PersistentVolumeClaim
-    api_version: v1
-    namespace: "{{ ansible_operator_meta.namespace }}"
-    name: "{{ item }}"
-    state: absent
-  loop:
-  - "postgres-{{ ansible_operator_meta.name }}-postgres-0"
-  - "postgres-{{ ansible_operator_meta.name }}-postgres-13-0"
-  when:
-    - not postgres_keep_pvc_after_upgrade
-
-- k8s_status:
-    api_version: "{{ api_version }}"
-    kind: "{{ kind }}"
-    name: "{{ ansible_operator_meta.name }}"
-    namespace: "{{ ansible_operator_meta.namespace }}"
-    conditions:
-      - type: Database-Ready
         message: All Postgres upgrade tasks ran successfully
         reason: DatabaseTasksFinished
         status: "True"


### PR DESCRIPTION
## Summary

Deprecates `postgres_keep_pvc_after_upgrade` in the CRD and removes the
implementation. The field has no effect going forward; old Postgres PVCs are
always preserved after upgrade, consistent with standard behavior across
platform operators.

- Mark field as `(Deprecated)` in CRD description
- Remove PVC deletion task from `upgrade_postgres.yml`
- Remove CSV specDescriptor entry
- Remove role default

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change