### PR TITLE
Bypass reset-admin-password, use update_or_create via Django shell

### DIFF
--- a/roles/galaxy-api/tasks/resource_configuration.yml
+++ b/roles/galaxy-api/tasks/resource_configuration.yml
@@ -24,7 +24,7 @@
   set_fact:
     _api_pod_name: "{{ _api_pod['resources'][0]['metadata']['name'] | default('') }}"
 
-- name: Check if the admin user is defined
+- name: Ensure admin superuser exists with correct password.
   kubernetes.core.k8s_exec:
     namespace: "{{ ansible_operator_meta.namespace }}"
     pod: "{{ _api_pod_name }}"
@@ -32,21 +32,14 @@
     command: >-
       bash -c "echo 'from django.contrib.auth import get_user_model;
       User = get_user_model();
-      nsu = User.objects.filter(is_superuser=True, username=\"admin\").count();
-      exit(0 if nsu > 0 else 1)'
-      | pulpcore-manager shell"
-  ignore_errors: true
-  register: users_result
-  changed_when: users_result.return_code > 0
-
-- name: Create admin user via Django if it doesn't exist.
-  kubernetes.core.k8s_exec:
-    namespace: "{{ ansible_operator_meta.namespace }}"
-    pod: "{{ _api_pod_name }}"
-    container: "api"
-    command: bash -c "ANSIBLE_REVERSE_RESOURCE_SYNC=false pulpcore-manager reset-admin-password --password '{{ admin_password }}'"
+      user, created = User.objects.update_or_create(
+        username=\"admin\",
+        defaults={\"is_superuser\": True, \"is_staff\": True}
+      );
+      user.set_password(\"{{ admin_password }}\");
+      user.save();
+      print(\"created\" if created else \"updated\")'
+      | ANSIBLE_REVERSE_RESOURCE_SYNC=false pulpcore-manager shell"
   register: result
-  changed_when: "'That username is already taken' not in result.stderr"
-  failed_when: "'That username is already taken' not in result.stderr and 'Successfully set password' not in result.stdout"
+  changed_when: "'created' in result.stdout"
   no_log: "{{ no_log }}"
-  when: users_result.return_code > 0

--- a/roles/galaxy-api/tasks/resource_configuration.yml
+++ b/roles/galaxy-api/tasks/resource_configuration.yml
@@ -30,13 +30,14 @@
     pod: "{{ _api_pod_name }}"
     container: "api"
     command: >-
-      bash -c "echo 'from django.contrib.auth import get_user_model;
+      bash -c "echo 'import base64;
+      from django.contrib.auth import get_user_model;
       User = get_user_model();
       user, created = User.objects.update_or_create(
         username=\"admin\",
         defaults={\"is_superuser\": True, \"is_staff\": True}
       );
-      user.set_password(\"{{ admin_password }}\");
+      user.set_password(base64.b64decode(\"{{ admin_password | b64encode }}\").decode());
       user.save();
       print(\"created\" if created else \"updated\")'
       | ANSIBLE_REVERSE_RESOURCE_SYNC=false pulpcore-manager shell"


### PR DESCRIPTION
## Summary

- Replace the two-task admin user flow (check-if-exists + `reset-admin-password`) with a single idempotent task using Django's `update_or_create` directly via `pulpcore-manager shell`
- Fixes the `UniqueViolation` crash and infinite operator reconciliation loop when an admin user exists with `is_superuser=False` (AAP-76361)
- Removes the operator's dependency on pulpcore's `reset-admin-password` management command

## Problem

When an admin user exists in the database with `is_superuser=False` (e.g. after a PostgreSQL md5→scram-sha-256 migration), the operator enters an infinite crash loop:

1. Operator checks for superuser admin → finds none (`filter(is_superuser=True)` returns 0)
2. Operator calls `pulpcore-manager reset-admin-password`
3. Command uses `get_or_create(username="admin", is_superuser=True, is_staff=True)` — lookup fails because flags don't match
4. INSERT fails with `UniqueViolation` (username already exists)
5. Operator retries on next reconciliation → same crash → infinite loop

## Fix

Single task using `update_or_create(username="admin", defaults={"is_superuser": True, "is_staff": True})`:

- **Lookup by `username` only** — no `UniqueViolation` regardless of flag state
- **`defaults` updates flags** on existing users — promotes a non-superuser admin, breaking the infinite loop
- **`set_password` runs unconditionally** — ensures password matches the K8s Secret
- **Idempotent** — `changed_when: "'created' in result.stdout"` reports changed only on first creation

Related: [AAP-76361](https://redhat.atlassian.net/browse/AAP-76361)

## Test plan

- [x] yamllint passes (no new violations)
- [x] ansible-lint passes (only pre-existing FQCN warnings on unchanged lines)
- [ ] CI integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)