### PR TITLE
Add task to run container-handle-image-data

### DIFF
--- a/roles/galaxy-api/tasks/resource_configuration.yml
+++ b/roles/galaxy-api/tasks/resource_configuration.yml
@@ -50,3 +50,11 @@
   failed_when: "'That username is already taken' not in result.stderr and 'Successfully set password' not in result.stdout"
   no_log: "{{ no_log }}"
   when: users_result.return_code > 0
+
+- name: Run container-handle-image-data to cleanup recoverable artifacts
+  kubernetes.core.k8s_exec:
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    pod: "{{ _api_pod_name }}"
+    container: "api"
+    command: bash -c "pulpcore-manager container-handle-image-data"
+  register: result


### PR DESCRIPTION
##### SUMMARY
This pull request runs pulpcore-manager container-handle-image-data on the API pod after it becomes available.  This command runs a process to recover artifacts which may have been orphaned during upgrades.

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
