### PR TITLE
[main] add initContainer for handle-image-data command

### DIFF
--- a/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
+++ b/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
@@ -330,6 +330,44 @@ spec:
               readOnly: false
               mountPath: "/var/lib/pulp"
 {% endif %}
+        - name: handle-image-data
+          image: {{ _image }}
+          imagePullPolicy: '{{ image_pull_policy }}'
+          command:
+            - /bin/bash
+            - -c
+            - |
+              pulpcore-manager container-handle-image-data || true
+{% if combined_api.resource_requirements is defined %}
+          resources: {{ combined_api.resource_requirements }}
+{% endif %}
+          env:
+            - name: POSTGRES_SERVICE_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ postgres_configuration_secret_name }}
+                  key: host
+            - name: POSTGRES_SERVICE_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ postgres_configuration_secret_name }}
+                  key: port
+            - name: HOME
+              value: "/var/lib/pulp"
+          volumeMounts:
+            - name: {{ ansible_operator_meta.name }}-server
+              mountPath: "/etc/pulp/settings.py"
+              subPath: settings.py
+              readOnly: true
+            - name: {{ ansible_operator_meta.name }}-db-fields-encryption
+              mountPath: "/etc/pulp/keys/database_fields.symmetric.key"
+              subPath: database_fields.symmetric.key
+              readOnly: true
+{% if is_file_storage %}
+            - name: file-storage
+              readOnly: false
+              mountPath: "/var/lib/pulp"
+{% endif %}
 {% if signing_secret is defined %}
         - name: gpg-importer
           image: "{{ _image }}"


### PR DESCRIPTION
##### SUMMARY
When upgrading from 2.6 to 2.7, the pulp_container migration adds a data field to the Manifest model but leaves it NULL for existing manifests. The operator never runs `pulpcore-manager container-handle-image-data` to populate it from the existing artifacts, which can result in broken execution environments after upgrade.

**Fix**
Add a handle-image-data init container that runs `pulpcore-manager container-handle-image-data` automatically after DB migrations. The command populates manifest.data from existing artifacts for all manifests (both synced and pushed) as part of the upgrade process, so customers don't have to run it manually.

The command is a no-op when all manifests already have data populated.

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
