### PR TITLE
fix: add missing CSV specDescriptor for pg_dump_suffix on Backup CR

### DIFF
--- a/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/galaxy-operator.clusterserviceversion.yaml
@@ -684,6 +684,12 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Additional parameters for the pg_dump command
+        displayName: pg_dump Suffix
+        path: pg_dump_suffix
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:text
       statusDescriptors:
       - displayName: Conditions
         path: conditions


### PR DESCRIPTION
## Summary

- Add missing CSV specDescriptor for `pg_dump_suffix` on the GalaxyBackup CR

The `pg_dump_suffix` field exists in the Backup CRD spec and in role defaults, but was
missing a corresponding specDescriptor entry in the ClusterServiceVersion. This means
the field does not appear in OLM/OperatorHub UI forms.

Discovered during review of the `postgres_skip_data` backports (AAP-80276 / AAP-80277).

## Test plan

- [ ] `make bundle` generates valid bundle with the new descriptor
- [ ] Verify `pg_dump_suffix` appears under Advanced in the OperatorHub Backup CR form

🤖 Generated with [Claude Code](https://claude.com/claude-code)