### PR TITLE
fix: pin kube-linter version to avoid GitHub API rate limits

### DIFF
--- a/.ci/scripts/kubelinter.sh
+++ b/.ci/scripts/kubelinter.sh
@@ -3,19 +3,13 @@
 
 set -euo pipefail
 
-RELEASE_INFO=$(curl --silent --show-error --fail https://api.github.com/repos/stackrox/kube-linter/releases/latest)
-RELEASE_NAME=$(echo "${RELEASE_INFO}" | jq --raw-output ".name")
-LOCATION=$(echo "${RELEASE_INFO}" \
-  | jq --raw-output ".assets[].browser_download_url" \
-  | grep --fixed-strings kube-linter-linux.tar.gz)
+KUBE_LINTER_VERSION="v0.8.3"
+TARGET="kube-linter-linux-${KUBE_LINTER_VERSION}.tar.gz"
+LOCATION="https://github.com/stackrox/kube-linter/releases/download/${KUBE_LINTER_VERSION}/kube-linter-linux.tar.gz"
 
-# Remove trailing whitespace
-RELEASE_NAME="${RELEASE_NAME%"${RELEASE_NAME##*[![:space:]]}"}"
-TARGET=kube-linter-linux-${RELEASE_NAME}.tar.gz
-# Skip downloading release if downloaded already, e.g. when the action is used multiple times.
-if [ ! -e $TARGET ]; then
-  curl --silent --show-error --fail --location --output $TARGET "$LOCATION"
-  tar -xf $TARGET
+if [ ! -e "$TARGET" ]; then
+  curl --silent --show-error --fail --location --output "$TARGET" "$LOCATION"
+  tar -xf "$TARGET"
 fi
 mkdir -p lint
 sudo -E kubectl get galaxy,galaxybackup,galaxyrestore,pvc,configmap,serviceaccount,secret,networkpolicy,ingress,service,deployment,statefulset,hpa,job,cronjob -o yaml > ./lint/k8s-all.yaml


### PR DESCRIPTION
## Summary

- Pin kube-linter to v0.8.3 instead of fetching the latest release via the GitHub API

The `kubelinter.sh` script calls `https://api.github.com/repos/stackrox/kube-linter/releases/latest` on every CI run to discover the download URL. When the unauthenticated API rate limit is hit (HTTP 403), the script exits with code 22 and **all subsequent CI steps are skipped** — including the actual tests, idle/un-idle validation, and backup/restore.

This was observed failing in PR #270 and is a recurring flaky failure source.

The fix pins the version and downloads directly from the release URL, eliminating the API dependency entirely.

## Test plan

- [ ] CI passes with the pinned kube-linter version
- [ ] kube-linter lint output is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)