### PR TITLE
[AAP-81982] Use `httpGet` for readiness probe

### DIFF
--- a/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
+++ b/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
@@ -217,10 +217,9 @@ spec:
             periodSeconds: 15
             timeoutSeconds: 5
           readinessProbe:
-            exec:
-              command:
-                - /usr/bin/readyz.py
-                - "/{{ pulp_combined_settings.galaxy_api_path_prefix }}/pulp/api/v3/status/"
+            httpGet:
+              path: "/{{ pulp_combined_settings.galaxy_api_path_prefix }}/pulp/api/v3/status/"
+              port: 8000
             failureThreshold: 10
             initialDelaySeconds: 30
             periodSeconds: 10

--- a/roles/galaxy-content/templates/galaxy-content.deployment.yaml.j2
+++ b/roles/galaxy-content/templates/galaxy-content.deployment.yaml.j2
@@ -229,10 +229,9 @@ spec:
             - protocol: TCP
               containerPort: 24816
           readinessProbe:
-            exec:
-              command:
-                - /usr/bin/readyz.py
-                - "{{ pulp_combined_settings.content_path_prefix | default('/pulp/content/') }}"
+            httpGet:
+              path: "{{ pulp_combined_settings.content_path_prefix | default('/pulp/content/') }}"
+              port: 24816
             failureThreshold: 10
             initialDelaySeconds: 30
             periodSeconds: 10


### PR DESCRIPTION
## SUMMARY
Issue: https://redhat.atlassian.net/browse/AAP-81982

Replace `readyz.py` cmd readiness probes with native Kubernetes `httpGet` probes on hub-api and hub-content pods.

The `exec` probe spawns `python3 /usr/bin/readyz.py` every 10 seconds, which bootstraps a full Python + Django process (~75 MB peak) for a simple HTTP health check. The process exits, but for some reason, the cgroup memory is not fully reclaimed, leaving behind dead processes and causing unbounded container memory growth of ~30 MB/hour (~720 MB/day) with zero users.

The `httpGet` probe performs the same health check (HTTP request to the content/api port) natively via Kubernetes with zero process spawns.

  ## Evidence
 A/B test on the same OCP cluster, zero users, 17+ hours:

  | | Before (exec readyz.py) | After (httpGet) |
  |---|---|---|
  | hub-api cgroup after 12h | 889 MB, growing ~30 MB/hour | 300 MB, stable |
  | hub-content cgroup | climbing continuously | 323 MB, stable |
  | Dead process memory (gap) | 539 MB and growing | negative (healthy) |
  | Probe health | Working | Working (Ready: True for 17h) |

  ## Related issue

  - [AAP-68883](https://redhat.atlassian.net/browse/AAP-68883) — original memory leak report, fix (`--max-requests`) only addressed worker recycling

