### PR TITLE
[AAP-83932] Run fix-squashed-migrations before migrate in pulp 3.105 bump

### DIFF
--- a/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
+++ b/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
@@ -298,6 +298,7 @@ spec:
             - /bin/bash
             - -c
             - |
+              set -e
               mkdir -p /var/lib/pulp/{tmp,media}
               pulpcore-manager fix-squashed-migrations
               pulpcore-manager migrate

--- a/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
+++ b/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
@@ -299,6 +299,7 @@ spec:
             - -c
             - |
               mkdir -p /var/lib/pulp/{tmp,media}
+              pulpcore-manager fix-squashed-migrations
               pulpcore-manager migrate
 {% if combined_api.resource_requirements is defined %}
           resources: {{ combined_api.resource_requirements }}


### PR DESCRIPTION
### Summary
```
  File "/usr/lib/python3.12/site-packages/django/db/migrations/loader.py", line 327, in check_consistent_history
    raise InconsistentMigrationHistory(
django.db.migrations.exceptions.InconsistentMigrationHistory: Migration core.0091_systemid is applied before its dependency core.0001_squashed_0090_char_to_text_field on database 'default'.
```

This is because when bumping pulp from pulp 3.73 (2.6) to 3.105 (2.7-next) we need to squash migrations (`pulpcore-manager fix-squashed-migrations`) before running 2.7 migrations.

This issue was reproduced in Azure operator deployment. And then fixed by adding `pulpcore-manager fix-squashed-migrations to initContainer.run-migrations before the migrate cmd.

Issue: https://redhat.atlassian.net/browse/AAP-83932