### PR TITLE
fix: remove unnecessary chmod from backup postgres task

### DIFF
--- a/roles/backup/tasks/postgres.yml
+++ b/roles/backup/tasks/postgres.yml
@@ -30,13 +30,6 @@
     command: >-
       touch {{ _backup_dir }}/pulp.db
 
-- name: Set permissions on file for database dump
-  k8s_exec:
-    namespace: "{{ backup_pvc_namespace }}"
-    pod: "{{ ansible_operator_meta.name }}-db-management"
-    command: >-
-      chmod 0600 {{ _backup_dir }}/pulp.db
-
 - name: Set pg_dump command
   set_fact:
     pgdump: >-


### PR DESCRIPTION
##### SUMMARY
Remove the unnecessary `chmod 0600` from the backup postgres task. This
step can fail on storage backends that enforce POSIX identity (e.g., AWS
EFS with access points).

The step is unnecessary - the restore path reads the dump file without
permission checks, and `pg_dump` overwrites any permissions set on the
precreated file.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### STEPS TO REPRODUCE AND EXTRA INFO
1. Configure Galaxy with an EFS-backed StorageClass using access points
   with enforced `uid`/`gid`
2. Create a Galaxy Backup CR
3. Observe failure on the chmod step