### PR TITLE
[AAP-82327] Update scaling down from 3.50 with 3.82.1

### DIFF
--- a/playbooks/check_pulp_dependency_versions.yml
+++ b/playbooks/check_pulp_dependency_versions.yml
@@ -3,7 +3,7 @@
 # Sometimes it is necessary to scale down deployments before an upgrade if there are breaking changes in the pulp dependencies.
 # Known incompatibilities to check for:
 #   * pulp_ansible < 0.23 is not compatible with 0.23.0 or later
-#   * pulpcore < 3.50 is not compatible with 3.50.0 or later
+#   * pulpcore < 3.82.1 is not compatible with 3.82.1 or later
 
 - name: Check for existing API deployment
   kubernetes.core.k8s_info:
@@ -79,7 +79,7 @@
             - _pulp_ansible_version_output.stdout | trim != ''
             - _pulp_ansible_version_output.stdout | trim is version('0.23.0', '<')
 
-        - name: Set scaling flag if pulpcore version is less than 3.50
+        - name: Set scaling flag if pulpcore version is less than 3.82.1
           ansible.builtin.set_fact:
             needs_scaling_down: true
           when:
@@ -87,7 +87,7 @@
             - _pulpcore_version_output.rc == 0
             - _pulpcore_version_output.stdout | trim != 'not_found'
             - _pulpcore_version_output.stdout | trim != ''
-            - _pulpcore_version_output.stdout | trim is version('3.50.0', '<')
+            - _pulpcore_version_output.stdout | trim is version('3.82.1', '<')
 
 - name: Scale down API, Worker, and Content deployments if needed
   when: needs_scaling_down | default(false)


### PR DESCRIPTION
##### SUMMARY
Issue: https://redhat.atlassian.net/browse/AAP-82327

During operator upgrade from 2.6 to 2.7, the pulpcore bump from 3.49 to 3.105 causes Hub API pods to fail with 
```
RuntimeError: Incompatible versions detected (core >= 3.82.1 needed)
```

This is caused by pulpcore's migration [0134_task_insert_trigger.py](https://github.com/pulp/pulpcore/blob/9e56a1e6522497b140dc170d4123571b77666c16/pulpcore/app/migrations/0134_task_insert_trigger.py#L79) which uses `RequireVersion("core", "3.82.1")` (to enforce that all running pulp components are at least 3.82.1 before proceeding). During a rolling update, old pods still running 3.49 and fails because of this.
