### PR TITLE
Switch to `/api/galaxy/status/healthz` endpoint for readiness and liveness probe

### DIFF
--- a/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
+++ b/roles/galaxy-api/templates/galaxy-api.deployment.yaml.j2
@@ -209,7 +209,7 @@ spec:
               containerPort: 8000
           livenessProbe:
             httpGet:
-              path: "/{{ pulp_combined_settings.galaxy_api_path_prefix }}/pulp/api/v3/status/"
+              path: "/{{ pulp_combined_settings.galaxy_api_path_prefix }}/status/healthz"
               port: 8000
               scheme: HTTP
             failureThreshold: 5
@@ -218,7 +218,7 @@ spec:
             timeoutSeconds: 5
           readinessProbe:
             httpGet:
-              path: "/{{ pulp_combined_settings.galaxy_api_path_prefix }}/pulp/api/v3/status/"
+              path: "/{{ pulp_combined_settings.galaxy_api_path_prefix }}/status/healthz"
               port: 8000
             failureThreshold: 10
             initialDelaySeconds: 30

--- a/roles/galaxy-web/templates/galaxy-web.deployment.yaml.j2
+++ b/roles/galaxy-web/templates/galaxy-web.deployment.yaml.j2
@@ -111,7 +111,7 @@ spec:
 {% endif %}
           livenessProbe:
             httpGet:
-              path: "/{{ pulp_combined_settings.galaxy_api_path_prefix }}/pulp/api/v3/status/"
+              path: "/{{ pulp_combined_settings.galaxy_api_path_prefix }}/status/healthz"
 {% if ingress_type | lower == 'route' and route_tls_termination_mechanism | lower == 'passthrough' %}
               port: 8443
               scheme: HTTPS
@@ -125,7 +125,7 @@ spec:
             timeoutSeconds: 10
           readinessProbe:
             httpGet:
-              path: "/{{ pulp_combined_settings.galaxy_api_path_prefix }}/pulp/api/v3/status/"
+              path: "/{{ pulp_combined_settings.galaxy_api_path_prefix }}/status/healthz"
 {% if ingress_type | lower == 'route' and route_tls_termination_mechanism | lower == 'passthrough' %}
               port: 8443
               scheme: HTTPS


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Issue: https://redhat.atlassian.net/browse/AAP-88905

Switch to more lightweight endpoint for the readiness and liveness probe health checks. Currently used endpoint  `/api/galaxy/pulp/api/v3/status/` is expensive, it checks DB, redis and worker heartbeats on every call. `/api/galaxy/status/healthz` returns a plain 200 when the service is up, which I believe is what the probe needs (and querying database should not be needed). 



##### ADDITIONAL INFORMATION
Galaxy already uses this in one of the cloud deployment https://github.com/ansible/galaxy_ng/blob/4bd4c3140317fd16299a36d37eeb8c7fccd785bb/openshift/clowder/clowd-app.yaml#L73

