### PR TITLE
fix: add --previous flag to capture crashed pod logs in CI

### DIFF
--- a/.github/workflows/scripts/show_logs.sh
+++ b/.github/workflows/scripts/show_logs.sh
@@ -46,14 +46,20 @@ echo ::endgroup::
 
 echo ::group::GALAXY_API_LOGS
 sudo -E kubectl logs -l app.kubernetes.io/name=galaxy-api --tail=10000 || true
+echo "--- previous (crashed) container logs ---"
+sudo -E kubectl logs -l app.kubernetes.io/name=galaxy-api --previous --tail=2000 || true
 echo ::endgroup::
 
 echo ::group::GALAXY_CONTENT_LOGS
 sudo -E kubectl logs -l app.kubernetes.io/name=galaxy-content --tail=10000 || true
+echo "--- previous (crashed) container logs ---"
+sudo -E kubectl logs -l app.kubernetes.io/name=galaxy-content --previous --tail=2000 || true
 echo ::endgroup::
 
 echo ::group::GALAXY_WORKER_LOGS
 sudo -E kubectl logs -l app.kubernetes.io/name=galaxy-worker --tail=10000 || true
+echo "--- previous (crashed) container logs ---"
+sudo -E kubectl logs -l app.kubernetes.io/name=galaxy-worker --previous --tail=2000 || true
 echo ::endgroup::
 
 echo ::group::GALAXY_WEB_LOGS


### PR DESCRIPTION
##### SUMMARY

When `galaxy-ng` pods enter `CrashLoopBackOff`, `kubectl logs` without `--previous` shows the newly restarted container, which has little output. The actual crash traceback is only available in the previous terminated container's logs.

This was identified while investigating why the CI has been timing out since ~2026-09-03: the `galaxy-api`, `galaxy-content`, and `galaxy-worker` pods all enter `CrashLoopBackOff` (9 restarts) within 25 minutes, but the existing `show_logs.sh` only captures current container logs, so the root cause is invisible in CI output.

Adds `--previous --tail=2000` to the log collection for those three components so the next CI run will surface the Python traceback or startup error causing the crash.

##### ISSUE TYPE
 - Docs Fix or other nominal change

##### COMPONENT NAME
 - CI

##### STEPS TO REPRODUCE AND EXTRA INFO

See CI run https://github.com/ansible/galaxy-operator/actions/runs/33616035716 — all five matrix jobs time out after 30 min with pods in `CrashLoopBackOff` but no crash output captured.