### PR TITLE
fix: use DB fields encryption key as the Django SECRET_KEY (alternate to #287)

### DIFF
--- a/roles/galaxy-config/tasks/main.yml
+++ b/roles/galaxy-config/tasks/main.yml
@@ -3,6 +3,12 @@
 - name: Configure Galaxy Server Secret
   include_tasks: combine_galaxy_settings.yml
 
+- name: Use DB fields encryption key as the Django SECRET_KEY
+  set_fact:
+    pulp_combined_settings: "{{ pulp_combined_settings | combine({'secret_key': db_fields_encryption_key}) }}"
+  no_log: "{{ no_log }}"
+  when: pulp_combined_settings.secret_key is not defined
+
 - name: Include redis role
   include_role:
     name: redis

--- a/roles/galaxy-config/tasks/main.yml
+++ b/roles/galaxy-config/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Use DB fields encryption key as the Django SECRET_KEY
   set_fact:
-    pulp_combined_settings: "{{ pulp_combined_settings | combine({'secret_key': db_fields_encryption_key}) }}"
+    pulp_combined_settings: "{{ pulp_combined_settings | combine({'secret_key': db_fields_encryption_secret_contents['resources'][0]['data']['database_fields.symmetric.key'] | b64decode}) }}"
   no_log: "{{ no_log }}"
   when: pulp_combined_settings.secret_key is not defined
 


### PR DESCRIPTION
## Summary

Alternate fix for the pulpcore 3.105.13 `SECRET_KEY` crash (`django.core.exceptions.ImproperlyConfigured: The SECRET_KEY setting must not be empty.`), also being addressed in #287.

Instead of generating and persisting a brand-new Secret for `SECRET_KEY`, this reuses the Fernet key the operator already generates and persists for `DB_ENCRYPTION_KEY` in `roles/common/tasks/db_fields_encryption_configuration.yml`. That key is already random (32 bytes / 256 bits of entropy from `cryptography.fernet.Fernet.generate_key()`), already has full backup/restore coverage, and already survives upgrades via its existing Secret.

Verified locally that a Fernet-format key works correctly as Django's `SECRET_KEY` (signs/verifies via `django.core.signing` with no errors). It does fall a few characters short of Django's own recommended 50-character minimum (`security.W009`), which is a soft warning only surfaced by `manage.py check --deploy` — neither pulpcore nor galaxy_ng invoke that anywhere, so it has no functional or CI impact.

This is intentionally a much smaller diff than #287 (one file, six lines) versus generating/tracking a wholly new secret. The tradeoff is reusing one key across two different cryptographic purposes (DB field encryption vs. Django session/CSRF signing) instead of keeping them separate. See the internal writeup linked below for the full pros/cons comparison between this approach and #287 before picking one.

##### ISSUE TYPE
- Bug fix

##### COMPONENT NAME
- Operator

##### STEPS TO REPRODUCE AND EXTRA INFO

Deploy galaxy-operator with `quay.io/ansible/galaxy-ng:latest` (any build after 2026-09-01). All api/content/worker pods crash immediately with `SECRET_KEY setting must not be empty`.
